### PR TITLE
refactor: test quality, dispatch complexity, and API completeness (closes #19, #20, #21, #18)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1690,11 +1690,11 @@ if(LIBSTATS_BUILD_TESTS)
     # These test platform capabilities and constants - most critical
 
     # Basic constants and platform tests
-    create_libstats_test(test_constants tests/test_constants.cpp)
+    create_libstats_gtest(test_constants tests/test_constants.cpp)
     create_libstats_test(test_cpu_detection tests/test_cpu_detection.cpp)
     create_libstats_test(test_simd_comprehensive tests/test_simd_comprehensive.cpp)
-    create_libstats_test(test_platform_optimizations tests/test_platform_optimizations.cpp)
-    create_libstats_test(test_simd_policy tests/test_simd_policy.cpp)
+    create_libstats_gtest(test_platform_optimizations tests/test_platform_optimizations.cpp)
+    create_libstats_gtest(test_simd_policy tests/test_simd_policy.cpp)
 
     # SIMD benchmark test (on-demand only, not in regular test suite due to runtime)
     create_libstats_test(benchmark_simd_all tests/benchmark_simd_all.cpp)
@@ -1705,11 +1705,11 @@ if(LIBSTATS_BUILD_TESTS)
     # Core mathematical and safety functionality
 
     # Consolidated numerical safety (safety.h + log_space_ops.h)
-    create_libstats_test(test_numerical_safety tests/test_numerical_safety.cpp)
+    create_libstats_gtest(test_numerical_safety tests/test_numerical_safety.cpp)
 
     # Consolidated error handling (error_handling.h)
-    create_libstats_test(test_error_handling_comprehensive
-                         tests/test_error_handling_comprehensive.cpp)
+    create_libstats_gtest(test_error_handling_comprehensive
+                          tests/test_error_handling_comprehensive.cpp)
 
     # Consolidated math utilities (math_utils.h)
     create_libstats_gtest(test_math_comprehensive tests/test_math_comprehensive.cpp)
@@ -1727,9 +1727,9 @@ if(LIBSTATS_BUILD_TESTS)
 
     # LEVEL 2b: Platform Capabilities thread_pool.h and work_stealing_pool.h - Thread pool
     # implementations
-    create_libstats_test(test_thread_pool tests/test_thread_pool.cpp)
+    create_libstats_gtest(test_thread_pool tests/test_thread_pool.cpp)
     if(LIBSTATS_CMAKE_HAS_CONCEPTS_HEADER AND LIBSTATS_CMAKE_HAS_RANGES_HEADER)
-        create_libstats_test(test_work_stealing_pool tests/test_work_stealing_pool.cpp)
+        create_libstats_gtest(test_work_stealing_pool tests/test_work_stealing_pool.cpp)
         set(LIBSTATS_HAS_WORK_STEALING_POOL_TEST TRUE)
     else()
         set(LIBSTATS_HAS_WORK_STEALING_POOL_TEST FALSE)
@@ -1746,16 +1746,16 @@ if(LIBSTATS_BUILD_TESTS)
     # Performance Infrastructure
 
     # parallel_execution.h - C++20 parallel execution with automatic fallback
-    create_libstats_test(test_parallel_execution_integration
-                         tests/test_parallel_execution_integration.cpp)
-    create_libstats_test(test_parallel_execution_comprehensive
-                         tests/test_parallel_execution_comprehensive.cpp)
+    create_libstats_gtest(test_parallel_execution_integration
+                          tests/test_parallel_execution_integration.cpp)
+    create_libstats_gtest(test_parallel_execution_comprehensive
+                          tests/test_parallel_execution_comprehensive.cpp)
 
     # benchmark.h - Performance measurement utilities
     create_libstats_test(test_benchmark_basic tests/test_benchmark_basic.cpp)
 
     # benchmark.h - Comprehensive benchmark infrastructure testing
-    create_libstats_test(test_benchmark tests/test_benchmark.cpp)
+    create_libstats_gtest(test_benchmark tests/test_benchmark.cpp)
 
     # PHASE 3 PERFORMANCE OPTIMIZATION FRAMEWORK (NEW TESTS) performance_history.h - Performance
     # data collection and analysis
@@ -1801,7 +1801,7 @@ if(LIBSTATS_BUILD_TESTS)
 
     # Atomic parameters test - Test lock-free parameter access and invalidation for all
     # distributions
-    create_libstats_test(test_atomic_parameters tests/test_atomic_parameters.cpp)
+    create_libstats_gtest(test_atomic_parameters tests/test_atomic_parameters.cpp)
 
     # uniform.h - Uniform distribution implementation
     create_libstats_test(test_uniform_basic tests/test_uniform_basic.cpp)

--- a/include/core/dispatch_thresholds.h
+++ b/include/core/dispatch_thresholds.h
@@ -46,436 +46,147 @@ constexpr std::size_t BATCH_FIT_MIN = 8;
 // Per-architecture parallel thresholds: (DistributionType, OperationType) → size
 // Derived from strategy_profile Release builds, 2026-04-12.
 //
-// Reading guide: the value is the smallest batch size at which a parallel
-// strategy (PARALLEL or WORK_STEALING) sustainably beats VECTORIZED through
-// the largest measured size (500K).  NEVER means it never does.
+// Reading guide: each value is the smallest batch size at which a parallel
+// strategy sustainably beats VECTORIZED up to 500K elements.
+// NEVER means VECTORIZED always wins on that machine for that operation.
+//
+// Table layout: {pdf, log_pdf, cdf} per distribution row.
+// Beta is excluded (NEVER across all architectures and operations).
 // ============================================================================
+
+/**
+ * @brief Thresholds for one distribution across the three scalar-batch operations.
+ */
+struct ThresholdRow {
+    std::size_t pdf;
+    std::size_t log_pdf;
+    std::size_t cdf;
+};
+
+/**
+ * @brief Empirical parallel thresholds for one SIMD architecture.
+ *
+ * Rows correspond to distributions in DistributionType enum order;
+ * see the per-architecture constexpr instances below for data.
+ */
+struct ArchTable {
+    ThresholdRow uniform;
+    ThresholdRow gaussian;
+    ThresholdRow exponential;
+    ThresholdRow discrete;
+    ThresholdRow poisson;
+    ThresholdRow gamma;
+    ThresholdRow student_t;
+    ThresholdRow chi_squared;
+};
 
 // --- NEON (Apple M1, 128-bit, 8C/8T, macOS/GCD) ---
 // data/profiles/dispatcher/2026-04-12T05-36-21Z_darwin-arm64_…_sha-6aef918
-
-constexpr std::size_t neon_parallel_threshold(DistributionType dist, OperationType op) {
-    if (op == OperationType::BATCH_FIT)
-        return BATCH_FIT_MIN;
-    if (dist == DistributionType::BETA)
-        return NEVER;
-
-    switch (dist) {
-        case DistributionType::UNIFORM:
-            switch (op) {
-                case OperationType::PDF:
-                    return NEVER;
-                case OperationType::LOG_PDF:
-                    return NEVER;
-                case OperationType::CDF:
-                    return 20000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAUSSIAN:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 100000;
-                case OperationType::CDF:
-                    return 10000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::EXPONENTIAL:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 100000;
-                case OperationType::CDF:
-                    return 20000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::DISCRETE:
-            switch (op) {
-                case OperationType::PDF:
-                    return 250000;
-                case OperationType::LOG_PDF:
-                    return 250000;
-                case OperationType::CDF:
-                    return 100000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::POISSON:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAMMA:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 20000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::STUDENT_T:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 250000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::CHI_SQUARED:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        default:
-            return NEVER;
-    }
-}
+constexpr ArchTable kNeon = {
+    /* uniform     */ {NEVER,  NEVER,  20000},
+    /* gaussian    */ {50000,  100000, 10000},
+    /* exponential */ {50000,  100000, 20000},
+    /* discrete    */ {250000, 250000, 100000},
+    /* poisson     */ {20000,  50000,  2000},
+    /* gamma       */ {20000,  20000,  2000},
+    /* student_t   */ {20000,  50000,  250000},
+    /* chi_squared */ {20000,  50000,  2000},
+};
 
 // --- AVX (Intel Ivy Bridge i7-3820QM, 128/256-bit, 4P/8T, macOS/GCD) ---
 // data/profiles/dispatcher/2026-04-12T05-55-52Z_darwin-x86_64_…_sha-e75c6e3
-
-constexpr std::size_t avx_parallel_threshold(DistributionType dist, OperationType op) {
-    if (op == OperationType::BATCH_FIT)
-        return BATCH_FIT_MIN;
-    if (dist == DistributionType::BETA)
-        return NEVER;
-
-    switch (dist) {
-        case DistributionType::UNIFORM:
-            switch (op) {
-                case OperationType::PDF:
-                    return NEVER;
-                case OperationType::LOG_PDF:
-                    return NEVER;
-                case OperationType::CDF:
-                    return 10000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAUSSIAN:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 20000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::EXPONENTIAL:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 100000;
-                case OperationType::CDF:
-                    return 20000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::DISCRETE:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::POISSON:
-            switch (op) {
-                case OperationType::PDF:
-                    return 2000;
-                case OperationType::LOG_PDF:
-                    return 10000;
-                case OperationType::CDF:
-                    return 5000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAMMA:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 20000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::STUDENT_T:
-            switch (op) {
-                case OperationType::PDF:
-                    return 100000;
-                case OperationType::LOG_PDF:
-                    return 100000;
-                case OperationType::CDF:
-                    return 100000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::CHI_SQUARED:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 20000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        default:
-            return NEVER;
-    }
-}
+constexpr ArchTable kAvx = {
+    /* uniform     */ {NEVER,  NEVER,  10000},
+    /* gaussian    */ {20000,  50000,  20000},
+    /* exponential */ {20000,  100000, 20000},
+    /* discrete    */ {50000,  50000,  50000},
+    /* poisson     */ {2000,   10000,  5000},
+    /* gamma       */ {20000,  20000,  2000},
+    /* student_t   */ {100000, 100000, 100000},
+    /* chi_squared */ {20000,  20000,  2000},
+};
 
 // --- AVX2 (Intel Kaby Lake i7-7820HQ, 256-bit, 4P/8T, macOS/GCD) ---
 // data/profiles/dispatcher/2026-04-12T05-27-04Z_darwin-x86_64_…_sha-0e4e9f1
-
-constexpr std::size_t avx2_parallel_threshold(DistributionType dist, OperationType op) {
-    if (op == OperationType::BATCH_FIT)
-        return BATCH_FIT_MIN;
-    if (dist == DistributionType::BETA)
-        return NEVER;
-
-    switch (dist) {
-        case DistributionType::UNIFORM:
-            switch (op) {
-                case OperationType::PDF:
-                    return NEVER;
-                case OperationType::LOG_PDF:
-                    return NEVER;
-                case OperationType::CDF:
-                    return 20000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAUSSIAN:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 250000;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::EXPONENTIAL:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 250000;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::DISCRETE:
-            switch (op) {
-                case OperationType::PDF:
-                    return 100000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::POISSON:
-            switch (op) {
-                case OperationType::PDF:
-                    return 10000;
-                case OperationType::LOG_PDF:
-                    return 20000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAMMA:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 5000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::STUDENT_T:
-            switch (op) {
-                case OperationType::PDF:
-                    return 100000;
-                case OperationType::LOG_PDF:
-                    return 100000;
-                case OperationType::CDF:
-                    return NEVER;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::CHI_SQUARED:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 100000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        default:
-            return NEVER;
-    }
-}
+constexpr ArchTable kAvx2 = {
+    /* uniform     */ {NEVER,  NEVER,  20000},
+    /* gaussian    */ {50000,  250000, 50000},
+    /* exponential */ {50000,  250000, 50000},
+    /* discrete    */ {100000, 50000,  50000},
+    /* poisson     */ {10000,  20000,  2000},
+    /* gamma       */ {50000,  50000,  5000},
+    /* student_t   */ {100000, 100000, NEVER},
+    /* chi_squared */ {50000,  100000, 2000},
+};
 
 // --- AVX-512 (AMD Ryzen 7 7445HS Zen 4, 512-bit, 6P/12T, Windows/MSVC) ---
 // data/profiles/dispatcher/2026-04-12T06-02-56Z_windows-x86_64_…_sha-32c0819
+constexpr ArchTable kAvx512 = {
+    /* uniform     */ {100000, 50000,  50000},
+    /* gaussian    */ {100000, NEVER,  50000},
+    /* exponential */ {50000,  250000, 100000},
+    /* discrete    */ {50000,  250000, 50000},
+    /* poisson     */ {10000,  20000,  10000},
+    /* gamma       */ {20000,  50000,  2000},
+    /* student_t   */ {20000,  250000, NEVER},
+    /* chi_squared */ {50000,  50000,  5000},
+};
 
-constexpr std::size_t avx512_parallel_threshold(DistributionType dist, OperationType op) {
-    if (op == OperationType::BATCH_FIT)
-        return BATCH_FIT_MIN;
-    if (dist == DistributionType::BETA)
-        return NEVER;
+/**
+ * @brief Single shared implementation: look up (dist, op) in one ArchTable.
+ *
+ * Replaces four structurally identical 35-CCN functions. Only the data
+ * (kNeon / kAvx / kAvx2 / kAvx512) differs between architectures.
+ */
+constexpr std::size_t parallelThresholdFromTable(const ArchTable& table,
+                                                  DistributionType dist,
+                                                  OperationType op) noexcept {
+    if (op == OperationType::BATCH_FIT) return BATCH_FIT_MIN;
+    if (dist == DistributionType::BETA)  return NEVER;
 
+    const ThresholdRow* row = nullptr;
     switch (dist) {
-        case DistributionType::UNIFORM:
-            switch (op) {
-                case OperationType::PDF:
-                    return 100000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAUSSIAN:
-            switch (op) {
-                case OperationType::PDF:
-                    return 100000;
-                case OperationType::LOG_PDF:
-                    return NEVER;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::EXPONENTIAL:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 250000;
-                case OperationType::CDF:
-                    return 100000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::DISCRETE:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 250000;
-                case OperationType::CDF:
-                    return 50000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::POISSON:
-            switch (op) {
-                case OperationType::PDF:
-                    return 10000;
-                case OperationType::LOG_PDF:
-                    return 20000;
-                case OperationType::CDF:
-                    return 10000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::GAMMA:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 2000;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::STUDENT_T:
-            switch (op) {
-                case OperationType::PDF:
-                    return 20000;
-                case OperationType::LOG_PDF:
-                    return 250000;
-                case OperationType::CDF:
-                    return NEVER;
-                default:
-                    return NEVER;
-            }
-        case DistributionType::CHI_SQUARED:
-            switch (op) {
-                case OperationType::PDF:
-                    return 50000;
-                case OperationType::LOG_PDF:
-                    return 50000;
-                case OperationType::CDF:
-                    return 5000;
-                default:
-                    return NEVER;
-            }
-        default:
-            return NEVER;
+        case DistributionType::UNIFORM:      row = &table.uniform;      break;
+        case DistributionType::GAUSSIAN:     row = &table.gaussian;     break;
+        case DistributionType::EXPONENTIAL:  row = &table.exponential;  break;
+        case DistributionType::DISCRETE:     row = &table.discrete;     break;
+        case DistributionType::POISSON:      row = &table.poisson;      break;
+        case DistributionType::GAMMA:        row = &table.gamma;        break;
+        case DistributionType::STUDENT_T:    row = &table.student_t;    break;
+        case DistributionType::CHI_SQUARED:  row = &table.chi_squared;  break;
+        default:                             return NEVER;
+    }
+    switch (op) {
+        case OperationType::PDF:     return row->pdf;
+        case OperationType::LOG_PDF: return row->log_pdf;
+        case OperationType::CDF:     return row->cdf;
+        default:                     return NEVER;
     }
 }
 
-// --- SSE2 fallback: shares AVX thresholds (similar 128-bit SIMD width) ---
+// Per-architecture wrappers — thin delegation to the shared implementation.
+constexpr std::size_t neon_parallel_threshold(DistributionType dist, OperationType op) {
+    return parallelThresholdFromTable(kNeon, dist, op);
+}
+constexpr std::size_t avx_parallel_threshold(DistributionType dist, OperationType op) {
+    return parallelThresholdFromTable(kAvx, dist, op);
+}
+constexpr std::size_t avx2_parallel_threshold(DistributionType dist, OperationType op) {
+    return parallelThresholdFromTable(kAvx2, dist, op);
+}
+constexpr std::size_t avx512_parallel_threshold(DistributionType dist, OperationType op) {
+    return parallelThresholdFromTable(kAvx512, dist, op);
+}
 
+// --- SSE2 fallback: shares AVX thresholds (similar 128-bit SIMD width) ---
 constexpr std::size_t sse2_parallel_threshold(DistributionType dist, OperationType op) {
     return avx_parallel_threshold(dist, op);
 }
 
 // --- No SIMD: conservative high thresholds ---
-
 constexpr std::size_t none_parallel_threshold(DistributionType dist, OperationType op) {
-    if (op == OperationType::BATCH_FIT)
-        return BATCH_FIT_MIN;
-    if (dist == DistributionType::BETA)
-        return NEVER;
+    if (op == OperationType::BATCH_FIT) return BATCH_FIT_MIN;
+    if (dist == DistributionType::BETA)  return NEVER;
     // Without SIMD, VECTORIZED is just a scalar loop via the batch path.
     // Parallel helps earlier because there is no SIMD advantage to protect.
     return 5000;

--- a/include/core/error_handling.h
+++ b/include/core/error_handling.h
@@ -157,10 +157,10 @@ inline VoidResult validateUniformParameters(double a, double b) noexcept {
  * @return VoidResult indicating success or failure
  */
 inline VoidResult validateDiscreteParameters(int a, int b) noexcept {
-    if (a > b) {
+    if (a >= b) {
         return VoidResult::makeError(
             ValidationError::InvalidRange,
-            "Upper bound (b) must be greater than or equal to lower bound (a)");
+            "Upper bound (b) must be strictly greater than lower bound (a)");
     }
 
     // Check for integer overflow in range calculation

--- a/include/core/log_space_ops.h
+++ b/include/core/log_space_ops.h
@@ -4,7 +4,6 @@
 #include "math_constants.h"
 #include "statistical_constants.h"
 
-#include <array>
 #include <cmath>
 #include <limits>
 
@@ -13,19 +12,15 @@ namespace stats {
 /**
  * @brief High-performance log-space arithmetic operations
  *
- * This class provides optimized implementations of log-space arithmetic
- * operations commonly used in statistical calculations. Key optimizations include:
- * - Precomputed lookup tables for frequently used values
- * - SIMD-vectorized operations
- * - Numerically stable log-sum-exp implementations
- * - Efficient handling of log(0) cases
+ * This class provides numerically stable log-space arithmetic operations
+ * commonly used in statistical calculations:
+ * - Numerically stable log-sum-exp (scalar and array)
+ * - SIMD-vectorized array operations via the max-shift trick
+ * - Efficient handling of log(0) via LOG_ZERO sentinel
  *
  * @note THREAD SAFETY:
- * - All operations are thread-safe after initialization
- * - Initialization is automatically thread-safe via std::once_flag
- * - Multiple threads can safely call all static methods concurrently
- * - The global initializer ensures tables are ready when library is loaded
- * - No additional synchronization is required for normal usage
+ * - All operations are thread-safe without any initialization requirement
+ * - @c initialize() is a no-op retained for API compatibility
  */
 class LogSpaceOps {
    public:
@@ -35,27 +30,22 @@ class LogSpaceOps {
     /// Threshold below which exp() terms are considered negligible
     static constexpr double LOG_SUM_THRESHOLD = detail::LOG_SUM_EXP_THRESHOLD;
 
-    /// Size of precomputed lookup tables
-    static constexpr std::size_t LOOKUP_TABLE_SIZE = detail::LOG_SPACE_LOOKUP_TABLE_SIZE;
-
     /**
-     * @brief Initialize precomputed lookup tables
-     * Call this once at program startup for optimal performance
+     * @brief No-op retained for API compatibility.
      *
-     * @note THREAD SAFETY:
-     * - This method is thread-safe and can be called from multiple threads
-     * - Uses std::once_flag internally to ensure initialization happens exactly once
-     * - Safe to call multiple times - subsequent calls are no-ops
-     * - The global initializer calls this automatically when the library is loaded
-     * - Manual calls are optional but can be used for explicit control
+     * The lookup-table optimization previously populated here was removed
+     * because 1024-point linear interpolation over [-50,0] only achieves
+     * ~6e-5 accuracy — insufficient for 1e-9 tolerances. All operations
+     * now use @c std::log1p / @c std::exp directly.
      */
     static void initialize();
 
     /**
      * @brief Numerically stable log-sum-exp: log(exp(a) + exp(b))
      *
-     * Highly optimized version using lookup tables and avoiding
-     * expensive exp/log operations when possible.
+     * Uses the max-shift trick to avoid catastrophic cancellation, then
+     * computes the correction via std::log1p(std::exp(diff)) for full
+     * machine-precision accuracy.
      *
      * @param logA First log value
      * @param logB Second log value
@@ -129,13 +119,6 @@ class LogSpaceOps {
     static double safeLog(double prob) noexcept { return (prob > 0.0) ? std::log(prob) : LOG_ZERO; }
 
    private:
-    /// Precomputed lookup table for log(1 + exp(x)) for x in [-50, 0]
-    static std::array<double, LOOKUP_TABLE_SIZE> logOnePlusExpTable_;
-    static bool initialized_;
-
-    /// Internal helper for lookup table access
-    static double lookupLogOnePlusExp(double x) noexcept;
-
     /// SIMD implementations
     static double logSumExpArraySIMD(const double* logValues, std::size_t size) noexcept;
     static double logSumExpArrayScalar(const double* logValues, std::size_t size) noexcept;

--- a/include/core/math_constants.h
+++ b/include/core/math_constants.h
@@ -243,9 +243,6 @@ inline constexpr double LOG_SUM_EXP_THRESHOLD = -50.0;
 /// Switch from linear to log-space when values drop below this
 inline constexpr double LOG_SPACE_THRESHOLD = 1.0e-50;
 
-/// Lookup table size for log-space operations
-inline constexpr std::size_t LOG_SPACE_LOOKUP_TABLE_SIZE = 1024;
-
 /// Continued fraction: treat as "large" above this value
 inline constexpr double LARGE_CONTINUED_FRACTION_VALUE = 1e30;
 

--- a/include/core/parallel_batch_fit.h
+++ b/include/core/parallel_batch_fit.h
@@ -1,0 +1,158 @@
+#pragma once
+
+/**
+ * @file core/parallel_batch_fit.h
+ * @brief Generic parallel batch-fitting helper for all distributions.
+ *
+ * detail::batchFitParallel<DistT>(datasets, results) handles all thread-pool
+ * submission, per-chunk error recording, serial fallback, and serial error
+ * wrapping. Every distribution's static parallelBatchFit delegates here,
+ * keeping only the type-specific results parameter at the call site.
+ *
+ * This replaces the duplicate implementations previously found in Gaussian,
+ * Exponential, Uniform, Discrete, Poisson, and Gamma, and provides the
+ * standard implementation for Chi-squared, Student's t, and Beta.
+ */
+
+#include "libstats/core/dispatch_thresholds.h"
+#include "libstats/platform/thread_pool.h"
+
+#include <atomic>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace stats {
+namespace detail {
+
+/**
+ * @brief Fit multiple independent datasets to the same distribution type in parallel.
+ *
+ * For @p num_datasets >= dispatch_table::BATCH_FIT_MIN: submits chunks to the
+ * global ThreadPool with full error recording and a serial fallback on pool
+ * failure. For smaller counts: runs serially with per-dataset error wrapping.
+ *
+ * @tparam DistT  Distribution type with a fit(const std::vector<double>&) method.
+ * @param datasets Input: one dataset per distribution fit.
+ * @param results  In/out: resized to datasets.size() if needed; each element
+ *                 receives the parameters fitted to the corresponding dataset.
+ */
+template <typename DistT>
+void batchFitParallel(const std::vector<std::vector<double>>& datasets,
+                       std::vector<DistT>& results) {
+    if (datasets.empty()) {
+        results.clear();
+        return;
+    }
+    if (results.size() != datasets.size()) {
+        results.resize(datasets.size());
+    }
+
+    const std::size_t num_datasets = datasets.size();
+
+    if (num_datasets >= dispatch_table::BATCH_FIT_MIN) {
+        // One mutex per DistT instantiation — serialises pool-pointer acquisition
+        // across concurrent callers without blocking unrelated distribution types.
+        static std::mutex pool_access_mutex;
+
+        try {
+            ThreadPool* pool_ptr = nullptr;
+            {
+                std::lock_guard<std::mutex> pool_lock(pool_access_mutex);
+                pool_ptr = &ParallelUtils::getGlobalThreadPool();
+            }
+
+            const std::size_t grain_size = std::max(std::size_t{1}, num_datasets / 8);
+            const std::size_t num_chunks = (num_datasets + grain_size - 1) / grain_size;
+
+            std::vector<std::future<void>> futures;
+            futures.reserve(num_chunks);
+
+            std::atomic<bool> has_error{false};
+            std::mutex error_mutex;
+            std::string error_message;
+
+            for (std::size_t i = 0; i < num_datasets; i += grain_size) {
+                const std::size_t chunk_start = i;
+                const std::size_t chunk_end = std::min(i + grain_size, num_datasets);
+
+                futures.push_back(pool_ptr->submit(
+                    [&datasets, &results, chunk_start, chunk_end,
+                     &has_error, &error_mutex, &error_message]() {
+                        try {
+                            for (std::size_t j = chunk_start; j < chunk_end; ++j) {
+                                results[j].fit(datasets[j]);
+                            }
+                        } catch (const std::exception& e) {
+                            std::lock_guard<std::mutex> lk(error_mutex);
+                            if (!has_error.load()) {
+                                error_message = "Parallel batch fit error in chunk [" +
+                                    std::to_string(chunk_start) + ", " +
+                                    std::to_string(chunk_end) + "): " + e.what();
+                                has_error.store(true, std::memory_order_release);
+                            }
+                        } catch (...) {
+                            std::lock_guard<std::mutex> lk(error_mutex);
+                            if (!has_error.load()) {
+                                error_message = "Unknown error in parallel batch fit chunk [" +
+                                    std::to_string(chunk_start) + ", " +
+                                    std::to_string(chunk_end) + ")";
+                                has_error.store(true, std::memory_order_release);
+                            }
+                        }
+                    }));
+            }
+
+            bool all_completed = true;
+            for (auto& f : futures) {
+                try {
+                    f.wait();
+                } catch (const std::exception& e) {
+                    std::lock_guard<std::mutex> lk(error_mutex);
+                    if (!has_error.load()) {
+                        error_message = "Future wait error: " + std::string(e.what());
+                        has_error.store(true, std::memory_order_release);
+                    }
+                    all_completed = false;
+                }
+            }
+
+            if (has_error.load()) {
+                std::lock_guard<std::mutex> lk(error_mutex);
+                throw std::runtime_error("Parallel batch fitting failed: " + error_message);
+            }
+            if (!all_completed) {
+                throw std::runtime_error(
+                    "Some parallel batch fitting tasks failed to complete properly");
+            }
+
+        } catch (const std::exception& e) {
+            // Pool setup or execution failed: serial fallback with wrapping.
+            for (std::size_t i = 0; i < num_datasets; ++i) {
+                try {
+                    results[i].fit(datasets[i]);
+                } catch (const std::exception& fit_error) {
+                    throw std::runtime_error(
+                        "Serial fallback failed for dataset " + std::to_string(i) +
+                        ": " + fit_error.what() +
+                        " (original parallel error: " + e.what() + ")");
+                }
+            }
+        }
+    } else {
+        // Below parallel threshold: run serially with per-dataset error wrapping.
+        for (std::size_t i = 0; i < num_datasets; ++i) {
+            try {
+                results[i].fit(datasets[i]);
+            } catch (const std::exception& e) {
+                throw std::runtime_error("Serial batch fit failed for dataset " +
+                    std::to_string(i) + ": " + e.what());
+            }
+        }
+    }
+}
+
+}  // namespace detail
+}  // namespace stats

--- a/include/distributions/beta.h
+++ b/include/distributions/beta.h
@@ -236,6 +236,18 @@ class BetaDistribution : public DistributionBase {
      */
     void fit(const std::vector<double>& values) override;
 
+    /**
+     * @brief Parallel batch fitting for multiple datasets.
+     *
+     * Efficiently fits Beta parameters to multiple independent datasets
+     * in parallel. Delegates to detail::batchFitParallel.
+     *
+     * @param datasets Vector of datasets, each with independent observations
+     * @param results  Vector to store fitted BetaDistribution objects
+     */
+    static void parallelBatchFit(const std::vector<std::vector<double>>& datasets,
+                                  std::vector<BetaDistribution>& results);
+
     /** @brief Reset to default (α = β = 1, Uniform). */
     void reset() noexcept override;
 

--- a/include/distributions/chi_squared.h
+++ b/include/distributions/chi_squared.h
@@ -331,6 +331,18 @@ class ChiSquaredDistribution : public DistributionBase {
     void fit(const std::vector<double>& values) override;
 
     /**
+     * @brief Parallel batch fitting for multiple datasets.
+     *
+     * Efficiently fits chi-squared parameters to multiple independent datasets
+     * in parallel. Delegates to detail::batchFitParallel.
+     *
+     * @param datasets Vector of datasets, each with independent observations
+     * @param results  Vector to store fitted ChiSquaredDistribution objects
+     */
+    static void parallelBatchFit(const std::vector<std::vector<double>>& datasets,
+                                  std::vector<ChiSquaredDistribution>& results);
+
+    /**
      * @brief Reset to default parameters (k = 1).
      */
     void reset() noexcept override;

--- a/include/distributions/student_t.h
+++ b/include/distributions/student_t.h
@@ -249,6 +249,18 @@ class StudentTDistribution : public DistributionBase {
      */
     void fit(const std::vector<double>& values) override;
 
+    /**
+     * @brief Parallel batch fitting for multiple datasets.
+     *
+     * Efficiently fits Student's t parameters to multiple independent datasets
+     * in parallel. Delegates to detail::batchFitParallel.
+     *
+     * @param datasets Vector of datasets, each with independent observations
+     * @param results  Vector to store fitted StudentTDistribution objects
+     */
+    static void parallelBatchFit(const std::vector<std::vector<double>>& datasets,
+                                  std::vector<StudentTDistribution>& results);
+
     /** @brief Reset to default parameters (ν = 1, Cauchy distribution). */
     void reset() noexcept override;
 

--- a/src/beta.cpp
+++ b/src/beta.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/beta.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/common/cpu_detection_fwd.h"
 #include "libstats/core/dispatch_utils.h"
@@ -482,6 +483,12 @@ void BetaDistribution::fit(const std::vector<double>& values) {
     }
 
     setParameters(alpha_cur, beta_cur);
+}
+
+void BetaDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<BetaDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void BetaDistribution::reset() noexcept {

--- a/src/chi_squared.cpp
+++ b/src/chi_squared.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/chi_squared.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/core/dispatch_utils.h"
 #include "libstats/core/math_utils.h"
@@ -160,6 +161,12 @@ void ChiSquaredDistribution::fit(const std::vector<double>& values) {
     const double sum = std::accumulate(values.begin(), values.end(), detail::ZERO_DOUBLE);
     const double k_hat = sum / static_cast<double>(values.size());
     setK(k_hat);
+}
+
+void ChiSquaredDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<ChiSquaredDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void ChiSquaredDistribution::reset() noexcept {

--- a/src/discrete.cpp
+++ b/src/discrete.cpp
@@ -2755,9 +2755,9 @@ void DiscreteDistribution::updateCacheUnsafe() const noexcept {
 
 // Static validation method moved from header for better compile times
 void DiscreteDistribution::validateParameters(int a, int b) {
-    if (a > b) {
+    if (a >= b) {
         throw std::invalid_argument(
-            "Upper bound (b) must be greater than or equal to lower bound (a)");
+            "Upper bound (b) must be strictly greater than lower bound (a)");
     }
     // Check for integer overflow in range calculation
     if (b > INT_MAX - 1 || a < INT_MIN + 1) {

--- a/src/discrete.cpp
+++ b/src/discrete.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/discrete.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 // Core functionality - lightweight headers
 #include "libstats/core/dispatch_thresholds.h"
@@ -637,52 +638,10 @@ void DiscreteDistribution::fit(const std::vector<double>& values) {
     cacheValidAtomic_.store(false, std::memory_order_release);
 }
 
-void DiscreteDistribution::parallelBatchFit(const std::vector<std::vector<double>>& datasets,
-                                            std::vector<DiscreteDistribution>& results) {
-    if (datasets.empty()) {
-        // Handle empty datasets gracefully
-        results.clear();
-        return;
-    }
-
-    // Ensure results vector has correct size
-    if (results.size() != datasets.size()) {
-        results.resize(datasets.size());
-    }
-
-    const std::size_t num_datasets = datasets.size();
-
-    // Use distribution-specific parallel thresholds for optimal work distribution
-    if (num_datasets >= detail::dispatch_table::BATCH_FIT_MIN) {
-        // Direct parallel execution without internal thresholds - bypass ParallelUtils limitation
-        ThreadPool& pool = ParallelUtils::getGlobalThreadPool();
-        const std::size_t optimal_grain_size = std::max(std::size_t{1}, num_datasets / 8);
-        std::vector<std::future<void>> futures;
-        futures.reserve((num_datasets + optimal_grain_size - 1) / optimal_grain_size);
-
-        for (std::size_t i = 0; i < num_datasets; i += optimal_grain_size) {
-            const std::size_t chunk_end = std::min(i + optimal_grain_size, num_datasets);
-
-            auto future = pool.submit([&datasets, &results, i, chunk_end]() {
-                for (std::size_t j = i; j < chunk_end; ++j) {
-                    results[j].fit(datasets[j]);
-                }
-            });
-
-            futures.push_back(std::move(future));
-        }
-
-        // Wait for all chunks to complete
-        for (auto& future : futures) {
-            future.wait();
-        }
-
-    } else {
-        // Serial processing for small numbers of datasets
-        for (std::size_t i = 0; i < num_datasets; ++i) {
-            results[i].fit(datasets[i]);
-        }
-    }
+void DiscreteDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<DiscreteDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void DiscreteDistribution::reset() noexcept {

--- a/src/exponential.cpp
+++ b/src/exponential.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/exponential.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/common/cpu_detection_fwd.h"  // CPU feature queries (lightweight)
 #include "libstats/core/log_space_ops.h"
@@ -431,144 +432,10 @@ void ExponentialDistribution::fit(const std::vector<double>& values) {
     setLambda(detail::ONE / sample_mean);
 }
 
-void ExponentialDistribution::parallelBatchFit(const std::vector<std::vector<double>>& datasets,
-                                               std::vector<ExponentialDistribution>& results) {
-    if (datasets.empty()) {
-        // Handle empty datasets gracefully
-        results.clear();
-        return;
-    }
-
-    // Ensure results vector has correct size
-    if (results.size() != datasets.size()) {
-        results.resize(datasets.size());
-    }
-
-    const std::size_t num_datasets = datasets.size();
-
-    // Use distribution-specific parallel thresholds for optimal work distribution
-    if (num_datasets >= detail::dispatch_table::BATCH_FIT_MIN) {
-        // Thread-safe parallel execution with proper exception handling
-        // Use a static mutex to synchronize access to the global thread pool from multiple threads
-        static std::mutex pool_access_mutex;
-
-        try {
-            ThreadPool* pool_ptr = nullptr;
-            {
-                // Brief lock to get thread pool reference - minimize lock contention
-                std::lock_guard<std::mutex> pool_lock(pool_access_mutex);
-                pool_ptr = &ParallelUtils::getGlobalThreadPool();
-            }
-
-            const std::size_t optimal_grain_size = std::max(std::size_t{1}, num_datasets / 8);
-            const std::size_t num_chunks =
-                (num_datasets + optimal_grain_size - 1) / optimal_grain_size;
-
-            // Pre-allocate futures with known size to avoid reallocation during concurrent access
-            std::vector<std::future<void>> futures;
-            futures.reserve(num_chunks);
-
-            // Atomic counter for tracking completion and error handling
-            std::atomic<std::size_t> completed_chunks{0};
-            std::atomic<bool> has_error{false};
-            std::mutex error_mutex;
-            std::string error_message;
-
-            // Submit all tasks with exception handling
-            for (std::size_t i = 0; i < num_datasets; i += optimal_grain_size) {
-                const std::size_t chunk_start = i;
-                const std::size_t chunk_end = std::min(i + optimal_grain_size, num_datasets);
-
-                auto future = pool_ptr->submit([&datasets, &results, chunk_start, chunk_end,
-                                                &completed_chunks, &has_error, &error_mutex,
-                                                &error_message]() {
-                    try {
-                        // Process chunk with local error handling
-                        for (std::size_t j = chunk_start; j < chunk_end; ++j) {
-                            results[j].fit(datasets[j]);
-                        }
-                        completed_chunks.fetch_add(1, std::memory_order_relaxed);
-                    } catch (const std::exception& e) {
-                        // Thread-safe error recording
-                        {
-                            std::lock_guard<std::mutex> error_lock(error_mutex);
-                            if (!has_error.load()) {
-                                error_message = "Parallel batch fit error in chunk [" +
-                                                std::to_string(chunk_start) + ", " +
-                                                std::to_string(chunk_end) + "): " + e.what();
-                                has_error.store(true, std::memory_order_release);
-                            }
-                        }
-                    } catch (...) {
-                        // Handle non-standard exceptions
-                        {
-                            std::lock_guard<std::mutex> error_lock(error_mutex);
-                            if (!has_error.load()) {
-                                error_message = "Unknown error in parallel batch fit chunk [" +
-                                                std::to_string(chunk_start) + ", " +
-                                                std::to_string(chunk_end) + ")";
-                                has_error.store(true, std::memory_order_release);
-                            }
-                        }
-                    }
-                });
-
-                futures.push_back(std::move(future));
-            }
-
-            // Wait for all chunks to complete with timeout and error checking
-            bool all_completed = true;
-            for (auto& future : futures) {
-                try {
-                    // Use wait() instead of get() to avoid exception re-throwing from task
-                    future.wait();
-                } catch (const std::exception& e) {
-                    // Handle future-related exceptions
-                    std::lock_guard<std::mutex> error_lock(error_mutex);
-                    if (!has_error.load()) {
-                        error_message = "Future wait error: " + std::string(e.what());
-                        has_error.store(true, std::memory_order_release);
-                    }
-                    all_completed = false;
-                }
-            }
-
-            // Check for errors after all futures complete
-            if (has_error.load()) {
-                std::lock_guard<std::mutex> error_lock(error_mutex);
-                throw std::runtime_error("Parallel batch fitting failed: " + error_message);
-            }
-
-            if (!all_completed) {
-                throw std::runtime_error(
-                    "Some parallel batch fitting tasks failed to complete properly");
-            }
-
-        } catch (const std::exception& e) {
-            // If parallel execution fails, fall back to serial execution
-            // This ensures robustness in case of thread pool issues
-            for (std::size_t i = 0; i < num_datasets; ++i) {
-                try {
-                    results[i].fit(datasets[i]);
-                } catch (const std::exception& fit_error) {
-                    throw std::runtime_error("Serial fallback failed for dataset " +
-                                             std::to_string(i) + ": " + fit_error.what() +
-                                             " (original parallel error: " + e.what() + ")");
-                }
-            }
-        }
-
-    } else {
-        // Serial processing for small numbers of datasets
-        for (std::size_t i = 0; i < num_datasets; ++i) {
-            try {
-                results[i].fit(datasets[i]);
-            } catch (const std::exception& e) {
-                throw std::runtime_error("Serial batch fit failed for dataset " +
-                                         std::to_string(i) + ": " + e.what());
-            }
-        }
-    }
+void ExponentialDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<ExponentialDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void ExponentialDistribution::reset() noexcept {

--- a/src/gamma.cpp
+++ b/src/gamma.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/gamma.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 // Core functionality - lightweight headers
 #include "libstats/core/dispatch_thresholds.h"
@@ -438,52 +439,10 @@ void GammaDistribution::fit(const std::vector<double>& values) {
     fitMaximumLikelihood(values);
 }
 
-void GammaDistribution::parallelBatchFit(const std::vector<std::vector<double>>& datasets,
-                                         std::vector<GammaDistribution>& results) {
-    if (datasets.empty()) {
-        // Handle empty datasets gracefully
-        results.clear();
-        return;
-    }
-
-    // Ensure results vector has correct size
-    if (results.size() != datasets.size()) {
-        results.resize(datasets.size());
-    }
-
-    const std::size_t num_datasets = datasets.size();
-
-    // Use distribution-specific parallel thresholds for optimal work distribution
-    if (num_datasets >= detail::dispatch_table::BATCH_FIT_MIN) {
-        // Direct parallel execution without internal thresholds - bypass ParallelUtils limitation
-        ThreadPool& pool = ParallelUtils::getGlobalThreadPool();
-        const std::size_t optimal_grain_size = std::max(std::size_t{1}, num_datasets / 8);
-        std::vector<std::future<void>> futures;
-        futures.reserve((num_datasets + optimal_grain_size - 1) / optimal_grain_size);
-
-        for (std::size_t i = 0; i < num_datasets; i += optimal_grain_size) {
-            const std::size_t chunk_end = std::min(i + optimal_grain_size, num_datasets);
-
-            auto future = pool.submit([&datasets, &results, i, chunk_end]() {
-                for (std::size_t j = i; j < chunk_end; ++j) {
-                    results[j].fit(datasets[j]);
-                }
-            });
-
-            futures.push_back(std::move(future));
-        }
-
-        // Wait for all chunks to complete
-        for (auto& future : futures) {
-            future.wait();
-        }
-
-    } else {
-        // Serial processing for small numbers of datasets
-        for (std::size_t i = 0; i < num_datasets; ++i) {
-            results[i].fit(datasets[i]);
-        }
-    }
+void GammaDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<GammaDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void GammaDistribution::reset() noexcept {

--- a/src/gaussian.cpp
+++ b/src/gaussian.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/gaussian.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/common/cpu_detection_fwd.h"       // CPU feature queries (lightweight)
 #include "libstats/common/platform_constants_fwd.h"  // Parallel thresholds (lightweight)
@@ -654,144 +655,10 @@ void GaussianDistribution::fit(const std::vector<double>& values) {
     setParameters(running_mean, sample_std);
 }
 
-void GaussianDistribution::parallelBatchFit(const std::vector<std::vector<double>>& datasets,
-                                            std::vector<GaussianDistribution>& results) {
-    if (datasets.empty()) {
-        // Handle empty datasets gracefully
-        results.clear();
-        return;
-    }
-
-    // Ensure results vector has correct size
-    if (results.size() != datasets.size()) {
-        results.resize(datasets.size());
-    }
-
-    const std::size_t num_datasets = datasets.size();
-
-    // Use distribution-specific parallel thresholds for optimal work distribution
-    if (num_datasets >= detail::dispatch_table::BATCH_FIT_MIN) {
-        // Thread-safe parallel execution with proper exception handling
-        // Use a static mutex to synchronize access to the global thread pool from multiple threads
-        static std::mutex pool_access_mutex;
-
-        try {
-            ThreadPool* pool_ptr = nullptr;
-            {
-                // Brief lock to get thread pool reference - minimize lock contention
-                std::lock_guard<std::mutex> pool_lock(pool_access_mutex);
-                pool_ptr = &ParallelUtils::getGlobalThreadPool();
-            }
-
-            const std::size_t optimal_grain_size = std::max(std::size_t{1}, num_datasets / 8);
-            const std::size_t num_chunks =
-                (num_datasets + optimal_grain_size - 1) / optimal_grain_size;
-
-            // Pre-allocate futures with known size to avoid reallocation during concurrent access
-            std::vector<std::future<void>> futures;
-            futures.reserve(num_chunks);
-
-            // Atomic counter for tracking completion and error handling
-            std::atomic<std::size_t> completed_chunks{0};
-            std::atomic<bool> has_error{false};
-            std::mutex error_mutex;
-            std::string error_message;
-
-            // Submit all tasks with exception handling
-            for (std::size_t i = 0; i < num_datasets; i += optimal_grain_size) {
-                const std::size_t chunk_start = i;
-                const std::size_t chunk_end = std::min(i + optimal_grain_size, num_datasets);
-
-                auto future = pool_ptr->submit([&datasets, &results, chunk_start, chunk_end,
-                                                &completed_chunks, &has_error, &error_mutex,
-                                                &error_message]() {
-                    try {
-                        // Process chunk with local error handling
-                        for (std::size_t j = chunk_start; j < chunk_end; ++j) {
-                            results[j].fit(datasets[j]);
-                        }
-                        completed_chunks.fetch_add(1, std::memory_order_relaxed);
-                    } catch (const std::exception& e) {
-                        // Thread-safe error recording
-                        {
-                            std::lock_guard<std::mutex> error_lock(error_mutex);
-                            if (!has_error.load()) {
-                                error_message = "Parallel batch fit error in chunk [" +
-                                                std::to_string(chunk_start) + ", " +
-                                                std::to_string(chunk_end) + "): " + e.what();
-                                has_error.store(true, std::memory_order_release);
-                            }
-                        }
-                    } catch (...) {
-                        // Handle non-standard exceptions
-                        {
-                            std::lock_guard<std::mutex> error_lock(error_mutex);
-                            if (!has_error.load()) {
-                                error_message = "Unknown error in parallel batch fit chunk [" +
-                                                std::to_string(chunk_start) + ", " +
-                                                std::to_string(chunk_end) + ")";
-                                has_error.store(true, std::memory_order_release);
-                            }
-                        }
-                    }
-                });
-
-                futures.push_back(std::move(future));
-            }
-
-            // Wait for all chunks to complete with timeout and error checking
-            bool all_completed = true;
-            for (auto& future : futures) {
-                try {
-                    // Use wait() instead of get() to avoid exception re-throwing from task
-                    future.wait();
-                } catch (const std::exception& e) {
-                    // Handle future-related exceptions
-                    std::lock_guard<std::mutex> error_lock(error_mutex);
-                    if (!has_error.load()) {
-                        error_message = "Future wait error: " + std::string(e.what());
-                        has_error.store(true, std::memory_order_release);
-                    }
-                    all_completed = false;
-                }
-            }
-
-            // Check for errors after all futures complete
-            if (has_error.load()) {
-                std::lock_guard<std::mutex> error_lock(error_mutex);
-                throw std::runtime_error("Parallel batch fitting failed: " + error_message);
-            }
-
-            if (!all_completed) {
-                throw std::runtime_error(
-                    "Some parallel batch fitting tasks failed to complete properly");
-            }
-
-        } catch (const std::exception& e) {
-            // If parallel execution fails, fall back to serial execution
-            // This ensures robustness in case of thread pool issues
-            for (std::size_t i = 0; i < num_datasets; ++i) {
-                try {
-                    results[i].fit(datasets[i]);
-                } catch (const std::exception& fit_error) {
-                    throw std::runtime_error("Serial fallback failed for dataset " +
-                                             std::to_string(i) + ": " + fit_error.what() +
-                                             " (original parallel error: " + e.what() + ")");
-                }
-            }
-        }
-
-    } else {
-        // Serial processing for small numbers of datasets
-        for (std::size_t i = 0; i < num_datasets; ++i) {
-            try {
-                results[i].fit(datasets[i]);
-            } catch (const std::exception& e) {
-                throw std::runtime_error("Serial batch fit failed for dataset " +
-                                         std::to_string(i) + ": " + e.what());
-            }
-        }
-    }
+void GaussianDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<GaussianDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void GaussianDistribution::reset() noexcept {

--- a/src/log_space_ops.cpp
+++ b/src/log_space_ops.cpp
@@ -12,34 +12,10 @@
 namespace stats {
 
 // =============================================================================
-// STATIC MEMBER INITIALIZATION
+// INITIALIZATION (no-op — lookup table removed)
 // =============================================================================
 
-std::array<double, LogSpaceOps::LOOKUP_TABLE_SIZE> LogSpaceOps::logOnePlusExpTable_{};
-bool LogSpaceOps::initialized_ = false;
-
-// =============================================================================
-// INITIALIZATION
-// =============================================================================
-
-void LogSpaceOps::initialize() {
-    if (initialized_) {
-        return;
-    }
-
-    // Precompute log(1 + exp(x)) for x in [-50, 0]
-    // This covers the range where numerical precision matters most
-    constexpr double x_min = -detail::FIFTY;
-    constexpr double x_max = 0.0;
-    constexpr double step = (x_max - x_min) / (LOOKUP_TABLE_SIZE - 1);
-
-    for (std::size_t i = 0; i < LOOKUP_TABLE_SIZE; ++i) {
-        double x = x_min + static_cast<double>(i) * step;
-        logOnePlusExpTable_[i] = std::log1p(std::exp(x));
-    }
-
-    initialized_ = true;
-}
+void LogSpaceOps::initialize() {}
 
 // =============================================================================
 // CORE LOG-SPACE OPERATIONS
@@ -59,19 +35,17 @@ double LogSpaceOps::logSumExp(double logA, double logB) noexcept {
         std::swap(logA, logB);
     }
 
-    double diff = logB - logA;
+    double diff = logB - logA;  // diff is in (-inf, 0]
 
     // If the difference is too large, the smaller term is negligible
     if (diff < LOG_SUM_THRESHOLD) {
         return logA;
     }
 
-    // Use lookup table for common range
-    if (diff >= -detail::FIFTY && diff <= detail::ZERO_DOUBLE) {
-        return logA + lookupLogOnePlusExp(diff);
-    }
-
-    // Fallback to direct computation
+    // Always use the numerically-exact direct computation.
+    // The lookup table (1024 points over [-50,0], step ~0.049) only achieves
+    // ~6e-5 interpolation accuracy — insufficient for the 1e-9 tolerances
+    // required by log-space arithmetic tests and downstream callers.
     return logA + std::log1p(std::exp(diff));
 }
 
@@ -152,40 +126,6 @@ void LogSpaceOps::logMatrixVectorMultiplyTransposed(const double* logMatrix,
             }
         }
     }
-}
-
-// =============================================================================
-// INTERNAL HELPER FUNCTIONS
-// =============================================================================
-
-double LogSpaceOps::lookupLogOnePlusExp(double x) noexcept {
-    // x should be in [-50, 0] for the lookup table
-    if (x < -detail::FIFTY) {
-        return std::exp(x);  // log(1 + exp(x)) ≈ exp(x) for very small x
-    }
-    if (x > detail::ZERO_DOUBLE) {
-        return x + std::log1p(std::exp(-x));  // Use alternative form for x > 0
-    }
-
-    // Linear interpolation in lookup table
-    constexpr double x_min = -detail::FIFTY;
-    constexpr double x_max = 0.0;
-    constexpr double step = (x_max - x_min) / (LOOKUP_TABLE_SIZE - 1);
-
-    const double index_real = (x - x_min) / step;
-    const std::size_t index_low = static_cast<std::size_t>(std::floor(index_real));
-    const std::size_t index_high = std::min(index_low + 1, LOOKUP_TABLE_SIZE - 1);
-
-    if (index_low >= LOOKUP_TABLE_SIZE - 1) {
-        return logOnePlusExpTable_[LOOKUP_TABLE_SIZE - detail::ONE_INT];
-    }
-
-    // Linear interpolation
-    const double frac = index_real - static_cast<double>(index_low);
-    const double low_val = logOnePlusExpTable_[index_low];
-    const double high_val = logOnePlusExpTable_[index_high];
-
-    return low_val + frac * (high_val - low_val);
 }
 
 // =============================================================================

--- a/src/performance_history.cpp
+++ b/src/performance_history.cpp
@@ -4,6 +4,7 @@
 #include "libstats/core/statistical_constants.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <vector>
 
@@ -178,90 +179,22 @@ std::string PerformanceHistory::generateKey(Strategy strategy, DistributionType 
 }
 
 std::size_t PerformanceHistory::categorizeBatchSize(std::size_t batch_size) noexcept {
-    // Enhanced categorization with better granularity around threshold boundaries
-    // Focus on preserving critical crossover points
-    if (batch_size <= 8)
-        return 8;
-    else if (batch_size <= 10)
-        return 10;
-    else if (batch_size <= 16)
-        return 16;
-    else if (batch_size <= 20)
-        return 20;
-    else if (batch_size <= 25)
-        return 25;
-    else if (batch_size <= 32)
-        return 32;
-    else if (batch_size <= 40)
-        return 40;
-    else if (batch_size <= 50)
-        return 50;
-    else if (batch_size <= 64)
-        return 64;
-    else if (batch_size <= 80)
-        return 80;
-    else if (batch_size <= detail::MAX_NEWTON_ITERATIONS)
-        return detail::MAX_NEWTON_ITERATIONS;
-    else if (batch_size <= 128)
-        return 128;
-    else if (batch_size <= 160)
-        return 160;
-    else if (batch_size <= 200)
-        return 200;
-    else if (batch_size <= 250)
-        return 250;
-    else if (batch_size <= 320)
-        return 320;
-    else if (batch_size <= 400)
-        return 400;
-    else if (batch_size <= 500)
-        return 500;
-    else if (batch_size <= 640)
-        return 640;
-    else if (batch_size <= 800)
-        return 800;
-    else if (batch_size <= detail::MAX_BISECTION_ITERATIONS)
-        return detail::MAX_BISECTION_ITERATIONS;
-    else if (batch_size <= 1280)
-        return 1280;
-    else if (batch_size <= 1600)
-        return 1600;
-    else if (batch_size <= 2000)
-        return 2000;
-    else if (batch_size <= 2500)
-        return 2500;
-    else if (batch_size <= 3200)
-        return 3200;
-    else if (batch_size <= 4000)
-        return 4000;
-    else if (batch_size <= detail::MAX_DATA_POINTS_FOR_SW_TEST)
-        return detail::MAX_DATA_POINTS_FOR_SW_TEST;
-    else if (batch_size <= 6400)
-        return 6400;
-    else if (batch_size <= 8000)
-        return 8000;
-    else if (batch_size <= 10000)
-        return 10000;
-    else if (batch_size <= 12800)
-        return 12800;
-    else if (batch_size <= 16000)
-        return 16000;
-    else if (batch_size <= 20000)
-        return 20000;
-    else if (batch_size <= 25000)
-        return 25000;
-    else if (batch_size <= 32000)
-        return 32000;
-    else if (batch_size <= 40000)
-        return 40000;
-    else if (batch_size <= 50000)
-        return 50000;
-    else if (batch_size <= 64000)
-        return 64000;
-    else if (batch_size <= 80000)
-        return 80000;
-    else
-        return 100000;
+    // Bucket boundaries in ascending order. Each value is both the threshold
+    // and the category label returned for all batch sizes up to that boundary.
+    // std::lower_bound selects the smallest bucket >= batch_size in O(log N).
+    static constexpr std::array<std::size_t, 41> kBuckets = {
+        8,     10,    16,    20,    25,
+        32,    40,    50,    64,    80,
+        100,   128,   160,   200,   250,
+        320,   400,   500,   640,   800,
+        1000,  1280,  1600,  2000,  2500,
+        3200,  4000,  5000,  6400,  8000,
+        10000, 12800, 16000, 20000, 25000,
+        32000, 40000, 50000, 64000, 80000,
+        100000
+    };
+    auto it = std::lower_bound(kBuckets.begin(), kBuckets.end(), batch_size);
+    return (it != kBuckets.end()) ? *it : kBuckets.back();
 }
 
 const char* PerformanceHistory::strategyToString(Strategy strategy) noexcept {

--- a/src/poisson.cpp
+++ b/src/poisson.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/poisson.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/core/math_constants.h"
 #include "libstats/core/statistical_constants.h"
@@ -475,52 +476,10 @@ void PoissonDistribution::fit(const std::vector<double>& values) {
     setLambda(sample_mean);
 }
 
-void PoissonDistribution::parallelBatchFit(const std::vector<std::vector<double>>& datasets,
-                                           std::vector<PoissonDistribution>& results) {
-    if (datasets.empty()) {
-        // Handle empty datasets gracefully
-        results.clear();
-        return;
-    }
-
-    // Ensure results vector has correct size
-    if (results.size() != datasets.size()) {
-        results.resize(datasets.size());
-    }
-
-    const std::size_t num_datasets = datasets.size();
-
-    // Use distribution-specific parallel thresholds for optimal work distribution
-    if (num_datasets >= detail::dispatch_table::BATCH_FIT_MIN) {
-        // Direct parallel execution without internal thresholds - bypass ParallelUtils limitation
-        ThreadPool& pool = ParallelUtils::getGlobalThreadPool();
-        const std::size_t optimal_grain_size = std::max(std::size_t{1}, num_datasets / 8);
-        std::vector<std::future<void>> futures;
-        futures.reserve((num_datasets + optimal_grain_size - 1) / optimal_grain_size);
-
-        for (std::size_t i = 0; i < num_datasets; i += optimal_grain_size) {
-            const std::size_t chunk_end = std::min(i + optimal_grain_size, num_datasets);
-
-            auto future = pool.submit([&datasets, &results, i, chunk_end]() {
-                for (std::size_t j = i; j < chunk_end; ++j) {
-                    results[j].fit(datasets[j]);
-                }
-            });
-
-            futures.push_back(std::move(future));
-        }
-
-        // Wait for all chunks to complete
-        for (auto& future : futures) {
-            future.wait();
-        }
-
-    } else {
-        // Serial processing for small numbers of datasets
-        for (std::size_t i = 0; i < num_datasets; ++i) {
-            results[i].fit(datasets[i]);
-        }
-    }
+void PoissonDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<PoissonDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void PoissonDistribution::reset() noexcept {

--- a/src/student_t.cpp
+++ b/src/student_t.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/student_t.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/common/cpu_detection_fwd.h"
 #include "libstats/core/dispatch_utils.h"
@@ -387,6 +388,12 @@ void StudentTDistribution::fit(const std::vector<double>& values) {
     }
 
     setNu(nu);
+}
+
+void StudentTDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<StudentTDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void StudentTDistribution::reset() noexcept {

--- a/src/uniform.cpp
+++ b/src/uniform.cpp
@@ -1,4 +1,5 @@
 #include "libstats/distributions/uniform.h"
+#include "libstats/core/parallel_batch_fit.h"
 
 #include "libstats/core/math_constants.h"
 #include "libstats/core/statistical_constants.h"
@@ -518,52 +519,10 @@ void UniformDistribution::fit(const std::vector<double>& values) {
     setBounds(fitted_a, fitted_b);
 }
 
-void UniformDistribution::parallelBatchFit(const std::vector<std::vector<double>>& datasets,
-                                           std::vector<UniformDistribution>& results) {
-    if (datasets.empty()) {
-        // Handle empty datasets gracefully
-        results.clear();
-        return;
-    }
-
-    // Ensure results vector has correct size
-    if (results.size() != datasets.size()) {
-        results.resize(datasets.size());
-    }
-
-    const std::size_t num_datasets = datasets.size();
-
-    // Use distribution-specific parallel thresholds for optimal work distribution
-    if (num_datasets >= detail::dispatch_table::BATCH_FIT_MIN) {
-        // Direct parallel execution without internal thresholds - bypass ParallelUtils limitation
-        ThreadPool& pool = ParallelUtils::getGlobalThreadPool();
-        const std::size_t optimal_grain_size = std::max(std::size_t{1}, num_datasets / 8);
-        std::vector<std::future<void>> futures;
-        futures.reserve((num_datasets + optimal_grain_size - 1) / optimal_grain_size);
-
-        for (std::size_t i = 0; i < num_datasets; i += optimal_grain_size) {
-            const std::size_t chunk_end = std::min(i + optimal_grain_size, num_datasets);
-
-            auto future = pool.submit([&datasets, &results, i, chunk_end]() {
-                for (std::size_t j = i; j < chunk_end; ++j) {
-                    results[j].fit(datasets[j]);
-                }
-            });
-
-            futures.push_back(std::move(future));
-        }
-
-        // Wait for all chunks to complete
-        for (auto& future : futures) {
-            future.wait();
-        }
-
-    } else {
-        // Serial processing for small numbers of datasets
-        for (std::size_t i = 0; i < num_datasets; ++i) {
-            results[i].fit(datasets[i]);
-        }
-    }
+void UniformDistribution::parallelBatchFit(
+    const std::vector<std::vector<double>>& datasets,
+    std::vector<UniformDistribution>& results) {
+    detail::batchFitParallel(datasets, results);
 }
 
 void UniformDistribution::reset() noexcept {

--- a/tests/test_atomic_parameters.cpp
+++ b/tests/test_atomic_parameters.cpp
@@ -1,391 +1,193 @@
 /**
  * @file test_atomic_parameters.cpp
- * @brief Test atomic parameter management for lock-free access in libstats distributions
- *
- * This test validates that the atomic parameter access methods work correctly,
- * provide proper performance characteristics for lock-free parameter access,
- * and properly handle atomic parameter invalidation when parameters change.
- *
- * @author libstats Development Team
- * @version 1.0.0
- * @since 1.0.0
+ * @brief GTest suite for atomic parameter management in libstats distributions
  */
-// Use focused headers for atomic parameters testing
 #include "libstats/distributions/discrete.h"
 #include "libstats/distributions/exponential.h"
 #include "libstats/distributions/gaussian.h"
 
-// Standard library includes
-#include <cassert>   // for assert
-#include <cmath>     // for std::abs
-#include <iostream>  // for std::cout, std::endl
-#include <utility>   // for std::move
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
 
 using namespace stats;
 
-/**
- * @brief Test basic atomic getter functionality for Exponential distribution
- */
-void test_exponential_atomic_getter() {
-    std::cout << "Testing Exponential distribution atomic getter..." << std::endl;
-
-    // Create exponential distribution
+TEST(AtomicParameters, ExponentialAtomicGetter) {
     auto result = ExponentialDistribution::create(2.5);
-    assert(result.isOk());
+    ASSERT_TRUE(result.isOk());
     auto exp_dist = std::move(result.value);
 
-    // Test that atomic getter returns same value as regular getter
     double lambda_regular = exp_dist.getLambda();
-    double lambda_atomic = exp_dist.getLambdaAtomic();
+    double lambda_atomic  = exp_dist.getLambdaAtomic();
 
-    assert(std::abs(lambda_regular - lambda_atomic) < 1e-15);
-    assert(std::abs(lambda_atomic - 2.5) < 1e-15);
+    EXPECT_NEAR(lambda_regular, lambda_atomic, 1e-15);
+    EXPECT_NEAR(lambda_atomic, 2.5, 1e-15);
 
-    std::cout << "  ✓ Regular getter: " << lambda_regular << std::endl;
-    std::cout << "  ✓ Atomic getter: " << lambda_atomic << std::endl;
-    std::cout << "  ✓ Values match perfectly" << std::endl;
+    std::cout << "  Regular: " << lambda_regular << ", Atomic: " << lambda_atomic << std::endl;
 }
 
-/**
- * @brief Test atomic getter consistency under parameter changes
- */
-void test_atomic_getter_consistency() {
-    std::cout << "Testing atomic getter consistency under parameter changes..." << std::endl;
-
+TEST(AtomicParameters, AtomicGetterConsistency) {
     auto result = ExponentialDistribution::create(1.0);
-    assert(result.isOk());
+    ASSERT_TRUE(result.isOk());
     auto exp_dist = std::move(result.value);
 
-    // Initial check
-    assert(std::abs(exp_dist.getLambdaAtomic() - 1.0) < 1e-15);
+    EXPECT_NEAR(exp_dist.getLambdaAtomic(), 1.0, 1e-15);
 
-    // Change parameter and verify atomic getter updates
     exp_dist.setLambda(3.5);
 
-    // Both getters should return the same updated value
-    [[maybe_unused]] double lambda_regular = exp_dist.getLambda();
-    double lambda_atomic = exp_dist.getLambdaAtomic();
+    double lambda_regular = exp_dist.getLambda();
+    double lambda_atomic  = exp_dist.getLambdaAtomic();
 
-    assert(std::abs(lambda_regular - lambda_atomic) < 1e-15);
-    assert(std::abs(lambda_atomic - 3.5) < 1e-15);
-
-    std::cout << "  ✓ Parameter change handled correctly" << std::endl;
-    std::cout << "  ✓ Updated atomic getter: " << lambda_atomic << std::endl;
+    EXPECT_NEAR(lambda_regular, lambda_atomic, 1e-15);
+    EXPECT_NEAR(lambda_atomic, 3.5, 1e-15);
+    std::cout << "  Updated atomic getter: " << lambda_atomic << std::endl;
 }
 
-/**
- * @brief Test Gaussian distribution atomic parameter invalidation
- */
-void test_gaussian_atomic_invalidation() {
-    std::cout << "Testing Gaussian atomic parameter invalidation..." << std::endl;
-
-    auto result = GaussianDistribution::create(1.0, 1.0);
-    assert(result.isOk());
+TEST(AtomicParameters, GaussianAtomicGetters) {
+    auto result = GaussianDistribution::create(5.0, 2.0);
+    ASSERT_TRUE(result.isOk());
     auto gauss_dist = std::move(result.value);
 
-    // Verify initial values
-    assert(std::abs(gauss_dist.getMeanAtomic() - 1.0) < 1e-15);
-    assert(std::abs(gauss_dist.getStandardDeviationAtomic() - 1.0) < 1e-15);
-    std::cout << "  ✓ Initial atomic values correct" << std::endl;
-
-    // Test setMean invalidation
-    gauss_dist.setMean(5.0);
-    assert(std::abs(gauss_dist.getMean() - 5.0) < 1e-15);
-    assert(std::abs(gauss_dist.getMeanAtomic() - 5.0) < 1e-15);
-    assert(std::abs(gauss_dist.getStandardDeviationAtomic() - 1.0) < 1e-15);
-    std::cout << "  ✓ setMean() properly invalidates and updates atomic parameters" << std::endl;
-
-    // Test setStandardDeviation invalidation
-    gauss_dist.setStandardDeviation(2.0);
-    assert(std::abs(gauss_dist.getStandardDeviation() - 2.0) < 1e-15);
-    assert(std::abs(gauss_dist.getMeanAtomic() - 5.0) < 1e-15);
-    assert(std::abs(gauss_dist.getStandardDeviationAtomic() - 2.0) < 1e-15);
-    std::cout << "  ✓ setStandardDeviation() properly invalidates and updates atomic parameters"
-              << std::endl;
-
-    // Test setParameters invalidation
-    gauss_dist.setParameters(10.0, 3.0);
-    assert(std::abs(gauss_dist.getMean() - 10.0) < 1e-15);
-    assert(std::abs(gauss_dist.getStandardDeviation() - 3.0) < 1e-15);
-    assert(std::abs(gauss_dist.getMeanAtomic() - 10.0) < 1e-15);
-    assert(std::abs(gauss_dist.getStandardDeviationAtomic() - 3.0) < 1e-15);
-    std::cout << "  ✓ setParameters() properly invalidates and updates atomic parameters"
-              << std::endl;
+    EXPECT_NEAR(gauss_dist.getMean(),              gauss_dist.getMeanAtomic(),              1e-15);
+    EXPECT_NEAR(gauss_dist.getStandardDeviation(), gauss_dist.getStandardDeviationAtomic(), 1e-15);
+    EXPECT_NEAR(gauss_dist.getMeanAtomic(), 5.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getStandardDeviationAtomic(), 2.0, 1e-15);
 }
 
-/**
- * @brief Test Exponential distribution atomic parameter invalidation
- */
-void test_exponential_atomic_invalidation() {
-    std::cout << "Testing Exponential atomic parameter invalidation..." << std::endl;
+TEST(AtomicParameters, DiscreteAtomicGetters) {
+    auto result = DiscreteDistribution::create(1, 10);
+    ASSERT_TRUE(result.isOk());
+    auto discrete_dist = std::move(result.value);
 
+    EXPECT_EQ(discrete_dist.getLowerBound(), discrete_dist.getLowerBoundAtomic());
+    EXPECT_EQ(discrete_dist.getUpperBound(), discrete_dist.getUpperBoundAtomic());
+    EXPECT_EQ(discrete_dist.getLowerBoundAtomic(), 1);
+    EXPECT_EQ(discrete_dist.getUpperBoundAtomic(), 10);
+}
+
+TEST(AtomicParameters, GaussianAtomicInvalidation) {
+    auto result = GaussianDistribution::create(1.0, 1.0);
+    ASSERT_TRUE(result.isOk());
+    auto gauss_dist = std::move(result.value);
+
+    EXPECT_NEAR(gauss_dist.getMeanAtomic(), 1.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getStandardDeviationAtomic(), 1.0, 1e-15);
+
+    gauss_dist.setMean(5.0);
+    EXPECT_NEAR(gauss_dist.getMean(), 5.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getMeanAtomic(), 5.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getStandardDeviationAtomic(), 1.0, 1e-15);
+
+    gauss_dist.setStandardDeviation(2.0);
+    EXPECT_NEAR(gauss_dist.getStandardDeviation(), 2.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getMeanAtomic(), 5.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getStandardDeviationAtomic(), 2.0, 1e-15);
+
+    gauss_dist.setParameters(10.0, 3.0);
+    EXPECT_NEAR(gauss_dist.getMeanAtomic(), 10.0, 1e-15);
+    EXPECT_NEAR(gauss_dist.getStandardDeviationAtomic(), 3.0, 1e-15);
+}
+
+TEST(AtomicParameters, ExponentialAtomicInvalidation) {
     auto result = ExponentialDistribution::create(1.0);
-    assert(result.isOk());
+    ASSERT_TRUE(result.isOk());
     auto exp_dist = std::move(result.value);
 
-    // Verify initial value
-    assert(std::abs(exp_dist.getLambdaAtomic() - 1.0) < 1e-15);
-    std::cout << "  ✓ Initial atomic value correct" << std::endl;
+    EXPECT_NEAR(exp_dist.getLambdaAtomic(), 1.0, 1e-15);
 
-    // Test setLambda invalidation
     exp_dist.setLambda(2.5);
-    assert(std::abs(exp_dist.getLambda() - 2.5) < 1e-15);
-    assert(std::abs(exp_dist.getLambdaAtomic() - 2.5) < 1e-15);
-    std::cout << "  ✓ setLambda() properly invalidates and updates atomic parameters" << std::endl;
+    EXPECT_NEAR(exp_dist.getLambda(), 2.5, 1e-15);
+    EXPECT_NEAR(exp_dist.getLambdaAtomic(), 2.5, 1e-15);
 
-    // Test trySetParameters invalidation
     auto try_result = exp_dist.trySetParameters(4.0);
-    assert(try_result.isOk());
-    assert(std::abs(exp_dist.getLambda() - 4.0) < 1e-15);
-    assert(std::abs(exp_dist.getLambdaAtomic() - 4.0) < 1e-15);
-    std::cout << "  ✓ trySetParameters() properly invalidates and updates atomic parameters"
-              << std::endl;
+    ASSERT_TRUE(try_result.isOk());
+    EXPECT_NEAR(exp_dist.getLambdaAtomic(), 4.0, 1e-15);
 }
 
-/**
- * @brief Test Discrete distribution atomic parameter invalidation
- */
-void test_discrete_atomic_invalidation() {
-    std::cout << "Testing Discrete atomic parameter invalidation..." << std::endl;
-
+TEST(AtomicParameters, DiscreteAtomicInvalidation) {
     auto result = DiscreteDistribution::create(1, 5);
-    assert(result.isOk());
+    ASSERT_TRUE(result.isOk());
     auto discrete_dist = std::move(result.value);
 
-    // Verify initial values
-    assert(discrete_dist.getLowerBoundAtomic() == 1);
-    assert(discrete_dist.getUpperBoundAtomic() == 5);
-    std::cout << "  ✓ Initial atomic values correct" << std::endl;
+    EXPECT_EQ(discrete_dist.getLowerBoundAtomic(), 1);
+    EXPECT_EQ(discrete_dist.getUpperBoundAtomic(), 5);
 
-    // Test setLowerBound invalidation
     discrete_dist.setLowerBound(0);
-    assert(discrete_dist.getLowerBound() == 0);
-    assert(discrete_dist.getLowerBoundAtomic() == 0);
-    assert(discrete_dist.getUpperBoundAtomic() == 5);
-    std::cout << "  ✓ setLowerBound() properly invalidates and updates atomic parameters"
-              << std::endl;
+    EXPECT_EQ(discrete_dist.getLowerBound(), 0);
+    EXPECT_EQ(discrete_dist.getLowerBoundAtomic(), 0);
+    EXPECT_EQ(discrete_dist.getUpperBoundAtomic(), 5);
 
-    // Test setUpperBound invalidation
     discrete_dist.setUpperBound(10);
-    assert(discrete_dist.getUpperBound() == 10);
-    assert(discrete_dist.getLowerBoundAtomic() == 0);
-    assert(discrete_dist.getUpperBoundAtomic() == 10);
-    std::cout << "  ✓ setUpperBound() properly invalidates and updates atomic parameters"
-              << std::endl;
+    EXPECT_EQ(discrete_dist.getUpperBoundAtomic(), 10);
 
-    // Test setBounds invalidation
     discrete_dist.setBounds(2, 8);
-    assert(discrete_dist.getLowerBound() == 2);
-    assert(discrete_dist.getUpperBound() == 8);
-    assert(discrete_dist.getLowerBoundAtomic() == 2);
-    assert(discrete_dist.getUpperBoundAtomic() == 8);
-    std::cout << "  ✓ setBounds() properly invalidates and updates atomic parameters" << std::endl;
+    EXPECT_EQ(discrete_dist.getLowerBoundAtomic(), 2);
+    EXPECT_EQ(discrete_dist.getUpperBoundAtomic(), 8);
 
-    // Test trySetParameters invalidation
     auto try_result = discrete_dist.trySetParameters(1, 6);
-    assert(try_result.isOk());
-    assert(discrete_dist.getLowerBound() == 1);
-    assert(discrete_dist.getUpperBound() == 6);
-    assert(discrete_dist.getLowerBoundAtomic() == 1);
-    assert(discrete_dist.getUpperBoundAtomic() == 6);
-    std::cout << "  ✓ trySetParameters() properly invalidates and updates atomic parameters"
-              << std::endl;
+    ASSERT_TRUE(try_result.isOk());
+    EXPECT_EQ(discrete_dist.getLowerBoundAtomic(), 1);
+    EXPECT_EQ(discrete_dist.getUpperBoundAtomic(), 6);
 }
 
-/**
- * @brief Test Gaussian distribution atomic getters if available
- */
-void test_gaussian_atomic_getters() {
-    std::cout << "Testing Gaussian distribution atomic getters..." << std::endl;
-
-    auto result = GaussianDistribution::create(5.0, 2.0);
-    assert(result.isOk());
-    auto gauss_dist = std::move(result.value);
-
-    // Test atomic getters with correct method names
-    double mean_regular = gauss_dist.getMean();
-    double stddev_regular = gauss_dist.getStandardDeviation();
-
-    // Check atomic getters
-    double mean_atomic = gauss_dist.getMeanAtomic();
-    double stddev_atomic = gauss_dist.getStandardDeviationAtomic();
-
-    assert(std::abs(mean_regular - mean_atomic) < 1e-15);
-    assert(std::abs(stddev_regular - stddev_atomic) < 1e-15);
-    assert(std::abs(mean_atomic - 5.0) < 1e-15);
-    assert(std::abs(stddev_atomic - 2.0) < 1e-15);
-
-    std::cout << "  ✓ Mean - Regular: " << mean_regular << ", Atomic: " << mean_atomic << std::endl;
-    std::cout << "  ✓ StdDev - Regular: " << stddev_regular << ", Atomic: " << stddev_atomic
-              << std::endl;
-}
-
-/**
- * @brief Test Discrete distribution atomic getters if available
- */
-void test_discrete_atomic_getters() {
-    std::cout << "Testing Discrete distribution atomic getters..." << std::endl;
-
-    auto result = DiscreteDistribution::create(1, 10);
-    assert(result.isOk());
-    auto discrete_dist = std::move(result.value);
-
-    // Test atomic getters with correct method names
-    int lower_regular = discrete_dist.getLowerBound();
-    int upper_regular = discrete_dist.getUpperBound();
-
-    // Check atomic getters
-    int lower_atomic = discrete_dist.getLowerBoundAtomic();
-    int upper_atomic = discrete_dist.getUpperBoundAtomic();
-
-    assert(lower_regular == lower_atomic);
-    assert(upper_regular == upper_atomic);
-    assert(lower_atomic == 1);
-    assert(upper_atomic == 10);
-
-    std::cout << "  ✓ Lower - Regular: " << lower_regular << ", Atomic: " << lower_atomic
-              << std::endl;
-    std::cout << "  ✓ Upper - Regular: " << upper_regular << ", Atomic: " << upper_atomic
-              << std::endl;
-}
-
-/**
- * @brief Simple performance comparison test
- */
-void test_performance_comparison() {
-    std::cout << "Testing basic performance comparison..." << std::endl;
-
+TEST(AtomicParameters, PerformanceComparison) {
     auto result = ExponentialDistribution::create(1.5);
-    assert(result.isOk());
+    ASSERT_TRUE(result.isOk());
     auto exp_dist = std::move(result.value);
 
     const int iterations = 100000;
+    for (int i = 0; i < 1000; ++i)
+        (void)exp_dist.getLambdaAtomic();  // warm up
 
-    // Warm up the cache
-    for (int i = 0; i < 1000; ++i) {
-        volatile double lambda = exp_dist.getLambdaAtomic();
-        (void)lambda;  // Suppress unused variable warning
-    }
-
-    // Time regular getter
-    auto start = std::chrono::high_resolution_clock::now();
+    auto t0 = std::chrono::high_resolution_clock::now();
     volatile double sum_regular = 0.0;
-    for (int i = 0; i < iterations; ++i) {
+    for (int i = 0; i < iterations; ++i)
         sum_regular = sum_regular + exp_dist.getLambda();
-    }
-    auto end = std::chrono::high_resolution_clock::now();
-    auto regular_time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+    auto t1 = std::chrono::high_resolution_clock::now();
 
-    // Time atomic getter
-    start = std::chrono::high_resolution_clock::now();
     volatile double sum_atomic = 0.0;
-    for (int i = 0; i < iterations; ++i) {
+    for (int i = 0; i < iterations; ++i)
         sum_atomic = sum_atomic + exp_dist.getLambdaAtomic();
-    }
-    end = std::chrono::high_resolution_clock::now();
-    auto atomic_time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+    auto t2 = std::chrono::high_resolution_clock::now();
 
-    double regular_per_call = static_cast<double>(regular_time.count()) / iterations;
-    double atomic_per_call = static_cast<double>(atomic_time.count()) / iterations;
+    auto ns_regular = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    auto ns_atomic  = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+    std::cout << "  Regular: " << ns_regular / iterations << " ns/call, "
+              << "Atomic: " << ns_atomic / iterations << " ns/call\n";
 
-    std::cout << "  Regular getter: " << regular_per_call << " ns/call" << std::endl;
-    std::cout << "  Atomic getter:  " << atomic_per_call << " ns/call" << std::endl;
-
-    // Atomic should typically be faster or comparable (when cache is valid)
-    if (atomic_per_call <= regular_per_call * 1.2) {  // Allow 20% margin
-        std::cout << "  ✓ Atomic getter performance is good" << std::endl;
-    } else {
-        std::cout << "  ⚠ Atomic getter is slower than expected (this may be normal during testing)"
-                  << std::endl;
-    }
-
-    // Verify the results are the same (within precision)
-    assert(std::abs(sum_regular - sum_atomic) < 1e-10);
+    // Both sums should converge to the same value
+    EXPECT_NEAR(sum_regular, sum_atomic, 1e-10);
 }
 
-/**
- * @brief Test thread safety of atomic getters
- */
-void test_thread_safety() {
-    std::cout << "Testing thread safety of atomic getters..." << std::endl;
-
+TEST(AtomicParameters, ThreadSafety) {
     auto result = ExponentialDistribution::create(2.0);
-    assert(result.isOk());
+    ASSERT_TRUE(result.isOk());
     auto exp_dist = std::move(result.value);
 
     const int num_threads = 4;
-    const int iterations_per_thread = 10000;
+    const int ops         = 10000;
     std::vector<std::thread> threads;
     std::atomic<int> success_count{0};
 
     for (int t = 0; t < num_threads; ++t) {
-        threads.emplace_back(
-            [&exp_dist, &success_count](int iterations) {
-                bool local_success = true;
-                for (int i = 0; i < iterations; ++i) {
-                    double lambda = exp_dist.getLambdaAtomic();
-                    if (std::abs(lambda - 2.0) > 1e-14) {
-                        local_success = false;
-                        break;
-                    }
-                }
-                if (local_success) {
-                    success_count++;
-                }
-            },
-            iterations_per_thread);
+        threads.emplace_back([&exp_dist, &success_count, ops]() {
+            bool ok = true;
+            for (int i = 0; i < ops && ok; ++i) {
+                if (std::abs(exp_dist.getLambdaAtomic() - 2.0) > 1e-14)
+                    ok = false;
+            }
+            if (ok) success_count++;
+        });
     }
 
-    for (auto& thread : threads) {
-        thread.join();
-    }
+    for (auto& thread : threads) thread.join();
 
-    assert(success_count.load() == num_threads);
-    std::cout << "  ✓ All " << num_threads << " threads completed successfully" << std::endl;
-    std::cout << "  ✓ Thread safety verified with " << (num_threads * iterations_per_thread)
-              << " total operations" << std::endl;
-}
-
-int main() {
-    std::cout << "=== Testing Atomic Parameter Management ===" << std::endl;
-    std::cout << std::endl;
-
-    try {
-        test_exponential_atomic_getter();
-        std::cout << std::endl;
-
-        test_atomic_getter_consistency();
-        std::cout << std::endl;
-
-        test_gaussian_atomic_getters();
-        std::cout << std::endl;
-
-        test_discrete_atomic_getters();
-        std::cout << std::endl;
-
-        test_gaussian_atomic_invalidation();
-        std::cout << std::endl;
-
-        test_exponential_atomic_invalidation();
-        std::cout << std::endl;
-
-        test_discrete_atomic_invalidation();
-        std::cout << std::endl;
-
-        test_performance_comparison();
-        std::cout << std::endl;
-
-        test_thread_safety();
-        std::cout << std::endl;
-
-        std::cout << "=== All Atomic Parameter Tests Passed! ===" << std::endl;
-        return 0;
-
-    } catch (const std::exception& e) {
-        std::cerr << "Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
-        std::cerr << "Test failed with unknown exception" << std::endl;
-        return 1;
-    }
+    EXPECT_EQ(success_count.load(), num_threads);
+    std::cout << "  Thread safety: " << num_threads << " threads x " << ops << " ops OK\n";
 }

--- a/tests/test_benchmark.cpp
+++ b/tests/test_benchmark.cpp
@@ -18,7 +18,7 @@
 
 // Standard library includes
 #include <algorithm>  // for std::min, std::max
-#include <cassert>    // for assert
+#include <gtest/gtest.h>
 #include <chrono>     // for std::chrono::high_resolution_clock, std::chrono::milliseconds
 #include <cmath>      // for std::abs
 #include <cstddef>    // for std::size_t
@@ -33,81 +33,11 @@ using namespace stats;
 // COMMAND-LINE ARGUMENT PARSING
 //==============================================================================
 
-struct TestOptions {
-    bool test_all = false;
-    bool test_timer = false;
-    bool test_stats = false;
-    bool test_benchmark = false;
-    bool test_comparison = false;
-    bool test_throughput = false;
-    bool test_stress = false;
-    bool show_help = false;
-};
+;
 
-void print_help() {
-    std::cout << "Usage: test_benchmark [options]\n\n";
-    std::cout << "Test platform/benchmark.h infrastructure with selective options:\n\n";
-    std::cout << "Options:\n";
-    std::cout << "  --all/-a           Test all benchmark components (default)\n";
-    std::cout << "  --timer/-t         Test Timer class functionality\n";
-    std::cout << "  --stats/-s         Test BenchmarkStats calculations\n";
-    std::cout << "  --benchmark/-b     Test Benchmark class operations\n";
-    std::cout << "  --comparison/-c    Test benchmark result comparisons\n";
-    std::cout << "  --throughput/-T    Test throughput measurements\n";
-    std::cout << "  --stress/-S        Run stress tests with large iterations\n";
-    std::cout << "  --help/-h          Show this help\n\n";
-    std::cout << "Examples:\n";
-    std::cout << "  test_benchmark                    # Test all components\n";
-    std::cout << "  test_benchmark --timer --stats   # Test Timer and BenchmarkStats\n";
-    std::cout << "  test_benchmark -b -c             # Test Benchmark class and comparisons\n";
-    std::cout << "  test_benchmark --stress           # Run stress tests\n";
-}
 
-TestOptions parse_arguments(int argc, char* argv[]) {
-    TestOptions options;
-    bool any_specific_test = false;
 
-    for (int i = 1; i < argc; ++i) {
-        std::string arg(argv[i]);
 
-        if (arg == "--all" || arg == "-a") {
-            options.test_all = true;
-        } else if (arg == "--timer" || arg == "-t") {
-            options.test_timer = true;
-            any_specific_test = true;
-        } else if (arg == "--stats" || arg == "-s") {
-            options.test_stats = true;
-            any_specific_test = true;
-        } else if (arg == "--benchmark" || arg == "-b") {
-            options.test_benchmark = true;
-            any_specific_test = true;
-        } else if (arg == "--comparison" || arg == "-c") {
-            options.test_comparison = true;
-            any_specific_test = true;
-        } else if (arg == "--throughput" || arg == "-T") {
-            options.test_throughput = true;
-            any_specific_test = true;
-        } else if (arg == "--stress" || arg == "-S") {
-            options.test_stress = true;
-            any_specific_test = true;
-        } else if (arg == "--help" || arg == "-h") {
-            options.show_help = true;
-            return options;
-        } else {
-            std::cerr << "Unknown option: " << arg << "\n";
-            std::cerr << "Use --help/-h for usage information.\n";
-            options.show_help = true;
-            return options;
-        }
-    }
-
-    // If no specific tests requested, default to all
-    if (!any_specific_test && !options.test_all) {
-        options.test_all = true;
-    }
-
-    return options;
-}
 
 //==============================================================================
 // TEST FUNCTIONS
@@ -121,32 +51,32 @@ void test_timer_functionality() {
         Timer timer;
 
         // Timer should not be running initially
-        assert(!timer.isRunning());
-        assert(timer.elapsed() == 0.0);
+        EXPECT_TRUE(!timer.isRunning());
+        EXPECT_TRUE(timer.elapsed() == 0.0);
 
         // Start timer
         timer.start();
-        assert(timer.isRunning());
+        EXPECT_TRUE(timer.isRunning());
 
         // Small delay
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
         // Check elapsed time
         [[maybe_unused]] double elapsed1 = timer.elapsed();
-        assert(elapsed1 > 0.0);
-        assert(timer.isRunning());  // Should still be running
+        EXPECT_TRUE(elapsed1 > 0.0);
+        EXPECT_TRUE(timer.isRunning());  // Should still be running
 
         // Another small delay
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
         // Elapsed should increase
         [[maybe_unused]] double elapsed2 = timer.elapsed();
-        assert(elapsed2 > elapsed1);
+        EXPECT_TRUE(elapsed2 > elapsed1);
 
         // Stop timer
         [[maybe_unused]] double final_time = timer.stop();
-        assert(!timer.isRunning());
-        assert(final_time >= elapsed2);
+        EXPECT_TRUE(!timer.isRunning());
+        EXPECT_TRUE(final_time >= elapsed2);
 
         std::cout << "   ✓ Basic timer functionality passed\n";
     }
@@ -161,13 +91,13 @@ void test_timer_functionality() {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
             double time = timer.stop();
             times.push_back(time);
-            assert(time > 0.0);
+            EXPECT_TRUE(time > 0.0);
         }
 
         // All times should be positive and reasonably consistent
         for ([[maybe_unused]] auto time : times) {
-            assert(time > 0.0);
-            assert(time < 1.0);  // Should be less than 1 second
+            EXPECT_TRUE(time > 0.0);
+            EXPECT_TRUE(time < 1.0);  // Should be less than 1 second
         }
 
         std::cout << "   ✓ Multiple timer cycles passed\n";
@@ -188,7 +118,7 @@ void test_timer_functionality() {
 
         // Timer should be reasonably accurate (within 20% due to scheduler variance)
         double relative_error = std::abs(timer_elapsed - reference_elapsed) / reference_elapsed;
-        assert(relative_error < 0.5);  // Allow 50% variance for CI environments
+        EXPECT_TRUE(relative_error < 0.5);  // Allow 50% variance for CI environments
 
         std::cout << "   ✓ Timer precision test passed (error: " << (relative_error * 100)
                   << "%)\n";
@@ -213,9 +143,9 @@ void test_benchmark_stats() {
 
         // Test toString functionality
         std::string stats_str = stats.toString();
-        assert(!stats_str.empty());
-        assert(stats_str.find("1.5") != std::string::npos);  // Should contain mean
-        assert(stats_str.find("100") != std::string::npos);  // Should contain sample count
+        EXPECT_TRUE(!stats_str.empty());
+        EXPECT_TRUE(stats_str.find("1.5") != std::string::npos);  // Should contain mean
+        EXPECT_TRUE(stats_str.find("100") != std::string::npos);  // Should contain sample count
 
         std::cout << "   ✓ BenchmarkStats structure test passed\n";
     }
@@ -229,7 +159,7 @@ void test_benchmark_stats() {
         stats.throughput = 0.0;
 
         std::string stats_str = stats.toString();
-        assert(!stats_str.empty());  // Should handle edge cases gracefully
+        EXPECT_TRUE(!stats_str.empty());  // Should handle edge cases gracefully
 
         std::cout << "   ✓ BenchmarkStats edge cases passed\n";
     }
@@ -257,11 +187,11 @@ void test_benchmark_class() {
 
         // Run benchmark
         auto results = bench.runAll();
-        assert(!results.empty());
-        assert(results.size() == 1);
-        assert(results[0].name == "simple_add");
-        assert(results[0].stats.samples > 0);
-        assert(results[0].stats.mean > 0.0);
+        EXPECT_TRUE(!results.empty());
+        EXPECT_TRUE(results.size() == 1);
+        EXPECT_TRUE(results[0].name == "simple_add");
+        EXPECT_TRUE(results[0].stats.samples > 0);
+        EXPECT_TRUE(results[0].stats.mean > 0.0);
 
         std::cout << "   ✓ Basic benchmark functionality passed\n";
     }
@@ -278,7 +208,7 @@ void test_benchmark_class() {
             "test2", []() { std::this_thread::sleep_for(std::chrono::microseconds(200)); }, 5);
 
         auto results = bench.runAll();
-        assert(results.size() == 2);
+        EXPECT_TRUE(results.size() == 2);
 
         // test2 should generally take longer than test1
         // (though this might be flaky in CI environments)
@@ -289,7 +219,7 @@ void test_benchmark_class() {
             if (result.name == "test2")
                 found_test2 = true;
         }
-        assert(found_test1 && found_test2);
+        EXPECT_TRUE(found_test1 && found_test2);
 
         std::cout << "   ✓ Multiple benchmark tests passed\n";
     }
@@ -313,9 +243,9 @@ void test_benchmark_class() {
         );
 
         auto results = bench.runAll();
-        assert(!results.empty());
-        assert(setup_count == 3);     // Should run setup 3 times
-        assert(teardown_count == 3);  // Should run teardown 3 times
+        EXPECT_TRUE(!results.empty());
+        EXPECT_TRUE(setup_count == 3);     // Should run setup 3 times
+        EXPECT_TRUE(teardown_count == 3);  // Should run teardown 3 times
 
         std::cout << "   ✓ Setup/teardown functionality passed\n";
     }
@@ -352,7 +282,7 @@ void test_benchmark_comparison() {
         Benchmark::compareResults(baseline, comparison, oss);
 
         std::string comparison_output = oss.str();
-        assert(!comparison_output.empty());
+        EXPECT_TRUE(!comparison_output.empty());
 
         std::cout << "   ✓ Benchmark comparison functionality passed\n";
     }
@@ -381,16 +311,16 @@ void test_throughput_measurements() {
             5, operations_per_iteration);
 
         auto results = bench.runAll();
-        assert(!results.empty());
+        EXPECT_TRUE(!results.empty());
 
         const auto& result = results[0];
-        assert(result.stats.throughput > 0.0);
+        EXPECT_TRUE(result.stats.throughput > 0.0);
 
         // Throughput should be operations per second
         double expected_ops_per_sec = operations_per_iteration / result.stats.mean;
         [[maybe_unused]] double relative_error =
             std::abs(result.stats.throughput - expected_ops_per_sec) / expected_ops_per_sec;
-        assert(relative_error < 0.1);  // Within 10%
+        EXPECT_TRUE(relative_error < 0.1);  // Within 10%
 
         std::cout << "   ✓ Throughput calculation test passed\n";
         std::cout << "     Throughput: " << result.stats.throughput << " ops/sec\n";
@@ -421,9 +351,9 @@ void test_stress_conditions() {
         auto results = bench.runAll();
         double total_time = stress_timer.stop();
 
-        assert(!results.empty());
-        assert(results[0].stats.samples == 100);
-        assert(total_time < 10.0);  // Should complete in reasonable time
+        EXPECT_TRUE(!results.empty());
+        EXPECT_TRUE(results[0].stats.samples == 100);
+        EXPECT_TRUE(total_time < 10.0);  // Should complete in reasonable time
 
         std::cout << "   ✓ High iteration stress test passed (" << total_time << "s)\n";
     }
@@ -447,9 +377,9 @@ void test_stress_conditions() {
             10);
 
         auto results = bench.runAll();
-        assert(!results.empty());
-        assert(results[0].stats.mean > 0.0);
-        assert(results[0].stats.stddev >= 0.0);
+        EXPECT_TRUE(!results.empty());
+        EXPECT_TRUE(results[0].stats.mean > 0.0);
+        EXPECT_TRUE(results[0].stats.stddev >= 0.0);
 
         std::cout << "   ✓ Memory allocation stress test passed\n";
     }
@@ -461,75 +391,10 @@ void test_stress_conditions() {
 // MAIN FUNCTION
 //==============================================================================
 
-int main(int argc, char* argv[]) {
-    TestOptions options = parse_arguments(argc, argv);
 
-    if (options.show_help) {
-        print_help();
-        return 0;
-    }
-
-    std::cout << "Testing platform/benchmark.h infrastructure...\n\n";
-
-    int tests_run = 0;
-    int tests_passed = 0;
-
-    try {
-        // Run selected tests
-        if (options.test_all || options.test_timer) {
-            test_timer_functionality();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_stats) {
-            test_benchmark_stats();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_benchmark) {
-            test_benchmark_class();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_comparison) {
-            test_benchmark_comparison();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_throughput) {
-            test_throughput_measurements();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_stress) {
-            test_stress_conditions();
-            tests_run++;
-            tests_passed++;
-        }
-
-        // Print summary
-        std::cout << "=== Test Summary ===\n";
-        std::cout << "Tests run: " << tests_run << "\n";
-        std::cout << "Tests passed: " << tests_passed << "\n";
-
-        if (tests_passed == tests_run && tests_run > 0) {
-            std::cout << "✓ All benchmark infrastructure tests passed!\n";
-            return 0;
-        } else if (tests_run == 0) {
-            std::cout << "No tests were run. Use --help for usage information.\n";
-            return 1;
-        } else {
-            std::cout << "✗ Some tests failed!\n";
-            return 1;
-        }
-
-    } catch (const std::exception& e) {
-        std::cerr << "Test failed with exception: " << e.what() << "\n";
-        return 1;
-    }
-}
+TEST(BenchmarkInfrastructure, TimerFunctionality)    { test_timer_functionality(); }
+TEST(BenchmarkInfrastructure, BenchmarkStats)        { test_benchmark_stats(); }
+TEST(BenchmarkInfrastructure, BenchmarkClass)        { test_benchmark_class(); }
+TEST(BenchmarkInfrastructure, Comparison)            { test_benchmark_comparison(); }
+TEST(BenchmarkInfrastructure, ThroughputMeasurements){ test_throughput_measurements(); }
+TEST(BenchmarkInfrastructure, StressConditions)      { test_stress_conditions(); }

--- a/tests/test_constants.cpp
+++ b/tests/test_constants.cpp
@@ -33,7 +33,7 @@
 
 // Standard library includes
 #include <algorithm>  // for std::min, std::max
-#include <cassert>    // for assert
+#include <gtest/gtest.h>
 #include <cmath>      // for std::abs, std::log, std::exp
 #include <cstddef>    // for std::size_t
 #include <iostream>   // for std::cout, std::endl
@@ -45,39 +45,39 @@ void test_math_constants() {
     using namespace stats::detail;
 
     // Pi and related constants
-    assert(std::abs(PI - 3.14159265358979323846) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(TWO_PI - (PI * 2)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(LN_PI - std::log(PI)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(PI - 3.14159265358979323846) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(TWO_PI - (PI * 2)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(LN_PI - std::log(PI)) < HIGH_PRECISION_TOLERANCE);
 
     // Test newly added mathematical constants
-    assert(std::abs(PHI - 1.6180339887498948482045868343656381) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(EULER_MASCHERONI - 0.5772156649015328606065120900824024) <
+    EXPECT_TRUE(std::abs(PHI - 1.6180339887498948482045868343656381) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(EULER_MASCHERONI - 0.5772156649015328606065120900824024) <
            HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(CATALAN - 0.9159655941772190150546035149323841) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(APERY - 1.2020569031595942853997381615114499) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(CATALAN - 0.9159655941772190150546035149323841) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(APERY - 1.2020569031595942853997381615114499) < HIGH_PRECISION_TOLERANCE);
 
     // Test derived constants
-    assert(std::abs(PHI_INV - (1.0 / PHI)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(PI_INV - (1.0 / PI)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(INV_SQRT_2PI - (1.0 / SQRT_2PI)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(INV_SQRT_2 - (1.0 / SQRT_2)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(INV_SQRT_3 - (1.0 / SQRT_3)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(PHI_INV - (1.0 / PHI)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(PI_INV - (1.0 / PI)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(INV_SQRT_2PI - (1.0 / SQRT_2PI)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(INV_SQRT_2 - (1.0 / SQRT_2)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(INV_SQRT_3 - (1.0 / SQRT_3)) < HIGH_PRECISION_TOLERANCE);
 
     // Test fractions and multiples
-    assert(std::abs(PI_OVER_2 - (PI / 2.0)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(PI_OVER_4 - (PI / 4.0)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(PI_OVER_6 - (PI / 6.0)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(FOUR_PI - (4.0 * PI)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(PI_OVER_2 - (PI / 2.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(PI_OVER_4 - (PI / 4.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(PI_OVER_6 - (PI / 6.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(FOUR_PI - (4.0 * PI)) < HIGH_PRECISION_TOLERANCE);
 
     // Test reciprocals
-    assert(std::abs(ONE_THIRD - (1.0 / 3.0)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(ONE_SIXTH - (1.0 / 6.0)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(ONE_TWELFTH - (1.0 / 12.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(ONE_THIRD - (1.0 / 3.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(ONE_SIXTH - (1.0 / 6.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(ONE_TWELFTH - (1.0 / 12.0)) < HIGH_PRECISION_TOLERANCE);
 
     // Test negative constants
-    assert(std::abs(NEG_TWO - (-2.0)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(NEG_HALF - (-0.5)) < HIGH_PRECISION_TOLERANCE);
-    assert(std::abs(NEG_HALF_LN_2PI - (-0.5 * LN_2PI)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(NEG_TWO - (-2.0)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(NEG_HALF - (-0.5)) < HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(std::abs(NEG_HALF_LN_2PI - (-0.5 * LN_2PI)) < HIGH_PRECISION_TOLERANCE);
 
     std::cout << "   ✓ Math constants tests passed" << std::endl;
 }
@@ -86,20 +86,20 @@ void test_probability_constants() {
     using namespace stats::detail;
 
     // Probability bounds
-    assert(MIN_PROBABILITY > 0.0);
-    assert(MAX_PROBABILITY < 1.0);
-    assert(MIN_LOG_PROBABILITY < MAX_LOG_PROBABILITY);
+    EXPECT_TRUE(MIN_PROBABILITY > 0.0);
+    EXPECT_TRUE(MAX_PROBABILITY < 1.0);
+    EXPECT_TRUE(MIN_LOG_PROBABILITY < MAX_LOG_PROBABILITY);
 
     // Test specific values
-    assert(MIN_PROBABILITY == 1.0e-300);
-    assert(MAX_PROBABILITY == 1.0 - 1.0e-15);
-    assert(MIN_LOG_PROBABILITY == -4605.0);
-    assert(MAX_LOG_PROBABILITY == 0.0);
+    EXPECT_TRUE(MIN_PROBABILITY == 1.0e-300);
+    EXPECT_TRUE(MAX_PROBABILITY == 1.0 - 1.0e-15);
+    EXPECT_TRUE(MIN_LOG_PROBABILITY == -4605.0);
+    EXPECT_TRUE(MAX_LOG_PROBABILITY == 0.0);
 
     // Test relationship between probability and log probability
     // Note: MIN_LOG_PROBABILITY is a safety clamp, not the actual log(MIN_PROBABILITY)
-    assert(std::log(MIN_PROBABILITY) > MIN_LOG_PROBABILITY);  // log(1e-300) ≈ -690.78 > -4605.0
-    assert(std::exp(MAX_LOG_PROBABILITY) <= MAX_PROBABILITY + 1e-15);
+    EXPECT_TRUE(std::log(MIN_PROBABILITY) > MIN_LOG_PROBABILITY);  // log(1e-300) ≈ -690.78 > -4605.0
+    EXPECT_TRUE(std::exp(MAX_LOG_PROBABILITY) <= MAX_PROBABILITY + 1e-15);
 
     std::cout << "   ✓ Probability constants tests passed" << std::endl;
 }
@@ -108,32 +108,32 @@ void test_precision_constants() {
     using namespace stats::detail;
 
     // Test precision hierarchy
-    assert(DEFAULT_TOLERANCE > HIGH_PRECISION_TOLERANCE);
-    assert(HIGH_PRECISION_TOLERANCE > ULTRA_HIGH_PRECISION_TOLERANCE);
-    assert(ULTRA_HIGH_PRECISION_TOLERANCE > 0.0);
+    EXPECT_TRUE(DEFAULT_TOLERANCE > HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(HIGH_PRECISION_TOLERANCE > ULTRA_HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(ULTRA_HIGH_PRECISION_TOLERANCE > 0.0);
 
     // Test specific values
-    assert(ZERO == 1.0e-30);
-    assert(DEFAULT_TOLERANCE == 1.0e-8);
-    assert(HIGH_PRECISION_TOLERANCE == 1.0e-12);
-    assert(ULTRA_HIGH_PRECISION_TOLERANCE == 1.0e-15);
+    EXPECT_TRUE(ZERO == 1.0e-30);
+    EXPECT_TRUE(DEFAULT_TOLERANCE == 1.0e-8);
+    EXPECT_TRUE(HIGH_PRECISION_TOLERANCE == 1.0e-12);
+    EXPECT_TRUE(ULTRA_HIGH_PRECISION_TOLERANCE == 1.0e-15);
 
     // Test machine epsilon values
-    assert(MACHINE_EPSILON == std::numeric_limits<double>::epsilon());
-    assert(MACHINE_EPSILON_FLOAT == std::numeric_limits<float>::epsilon());
-    assert(MACHINE_EPSILON_LONG_DOUBLE == std::numeric_limits<long double>::epsilon());
+    EXPECT_TRUE(MACHINE_EPSILON == std::numeric_limits<double>::epsilon());
+    EXPECT_TRUE(MACHINE_EPSILON_FLOAT == std::numeric_limits<float>::epsilon());
+    EXPECT_TRUE(MACHINE_EPSILON_LONG_DOUBLE == std::numeric_limits<long double>::epsilon());
 
     // Test numerical method tolerances
-    assert(NEWTON_RAPHSON_TOLERANCE > 0.0);
-    assert(BISECTION_TOLERANCE > 0.0);
-    assert(GRADIENT_DESCENT_TOLERANCE > 0.0);
-    assert(CONJUGATE_GRADIENT_TOLERANCE > 0.0);
+    EXPECT_TRUE(NEWTON_RAPHSON_TOLERANCE > 0.0);
+    EXPECT_TRUE(BISECTION_TOLERANCE > 0.0);
+    EXPECT_TRUE(GRADIENT_DESCENT_TOLERANCE > 0.0);
+    EXPECT_TRUE(CONJUGATE_GRADIENT_TOLERANCE > 0.0);
 
     // Test iteration limits
-    assert(MAX_NEWTON_ITERATIONS > 0);
-    assert(MAX_BISECTION_ITERATIONS > 0);
-    assert(MAX_GRADIENT_DESCENT_ITERATIONS > 0);
-    assert(MAX_CONJUGATE_GRADIENT_ITERATIONS > 0);
+    EXPECT_TRUE(MAX_NEWTON_ITERATIONS > 0);
+    EXPECT_TRUE(MAX_BISECTION_ITERATIONS > 0);
+    EXPECT_TRUE(MAX_GRADIENT_DESCENT_ITERATIONS > 0);
+    EXPECT_TRUE(MAX_CONJUGATE_GRADIENT_ITERATIONS > 0);
 
     std::cout << "   ✓ Precision constants tests passed" << std::endl;
 }
@@ -142,72 +142,72 @@ void test_simd_constants() {
     using namespace stats::arch::simd;
 
     // Test SIMD parameters
-    assert(DEFAULT_BLOCK_SIZE > 0);
-    assert(MIN_SIMD_SIZE > 0);
-    assert(MAX_BLOCK_SIZE >= DEFAULT_BLOCK_SIZE);
-    assert(DEFAULT_BLOCK_SIZE >= MIN_SIMD_SIZE);
+    EXPECT_TRUE(DEFAULT_BLOCK_SIZE > 0);
+    EXPECT_TRUE(MIN_SIMD_SIZE > 0);
+    EXPECT_TRUE(MAX_BLOCK_SIZE >= DEFAULT_BLOCK_SIZE);
+    EXPECT_TRUE(DEFAULT_BLOCK_SIZE >= MIN_SIMD_SIZE);
 
     // Test SIMD alignment constants
-    assert(AVX512_ALIGNMENT == 64);
-    assert(AVX_ALIGNMENT == 32);
-    assert(SSE_ALIGNMENT == 16);
-    assert(NEON_ALIGNMENT == 16);
-    assert(CACHE_LINE_ALIGNMENT == 64);
-    assert(MIN_SAFE_ALIGNMENT == 8);
+    EXPECT_TRUE(AVX512_ALIGNMENT == 64);
+    EXPECT_TRUE(AVX_ALIGNMENT == 32);
+    EXPECT_TRUE(SSE_ALIGNMENT == 16);
+    EXPECT_TRUE(NEON_ALIGNMENT == 16);
+    EXPECT_TRUE(CACHE_LINE_ALIGNMENT == 64);
+    EXPECT_TRUE(MIN_SAFE_ALIGNMENT == 8);
 
     // Test alignment hierarchy
-    assert(AVX512_ALIGNMENT >= AVX_ALIGNMENT);
-    assert(AVX_ALIGNMENT >= SSE_ALIGNMENT);
-    assert(SSE_ALIGNMENT == NEON_ALIGNMENT);
-    assert(SSE_ALIGNMENT >= MIN_SAFE_ALIGNMENT);
+    EXPECT_TRUE(AVX512_ALIGNMENT >= AVX_ALIGNMENT);
+    EXPECT_TRUE(AVX_ALIGNMENT >= SSE_ALIGNMENT);
+    EXPECT_TRUE(SSE_ALIGNMENT == NEON_ALIGNMENT);
+    EXPECT_TRUE(SSE_ALIGNMENT >= MIN_SAFE_ALIGNMENT);
 
     // Test all alignments are powers of 2
-    assert((AVX512_ALIGNMENT & (AVX512_ALIGNMENT - 1)) == 0);
-    assert((AVX_ALIGNMENT & (AVX_ALIGNMENT - 1)) == 0);
-    assert((SSE_ALIGNMENT & (SSE_ALIGNMENT - 1)) == 0);
-    assert((CACHE_LINE_ALIGNMENT & (CACHE_LINE_ALIGNMENT - 1)) == 0);
+    EXPECT_TRUE((AVX512_ALIGNMENT & (AVX512_ALIGNMENT - 1)) == 0);
+    EXPECT_TRUE((AVX_ALIGNMENT & (AVX_ALIGNMENT - 1)) == 0);
+    EXPECT_TRUE((SSE_ALIGNMENT & (SSE_ALIGNMENT - 1)) == 0);
+    EXPECT_TRUE((CACHE_LINE_ALIGNMENT & (CACHE_LINE_ALIGNMENT - 1)) == 0);
 
     // Test matrix block sizes
-    assert(MATRIX_L1_BLOCK_SIZE == 64);
-    assert(MATRIX_L2_BLOCK_SIZE == 256);
-    assert(MATRIX_L3_BLOCK_SIZE == 1024);
-    assert(MATRIX_STEP_SIZE == 8);
-    assert(MATRIX_PANEL_WIDTH == 64);
-    assert(MATRIX_MIN_BLOCK_SIZE == 32);
-    assert(MATRIX_MAX_BLOCK_SIZE == 2048);
+    EXPECT_TRUE(MATRIX_L1_BLOCK_SIZE == 64);
+    EXPECT_TRUE(MATRIX_L2_BLOCK_SIZE == 256);
+    EXPECT_TRUE(MATRIX_L3_BLOCK_SIZE == 1024);
+    EXPECT_TRUE(MATRIX_STEP_SIZE == 8);
+    EXPECT_TRUE(MATRIX_PANEL_WIDTH == 64);
+    EXPECT_TRUE(MATRIX_MIN_BLOCK_SIZE == 32);
+    EXPECT_TRUE(MATRIX_MAX_BLOCK_SIZE == 2048);
 
     // Test matrix block size hierarchy
-    assert(MATRIX_L3_BLOCK_SIZE >= MATRIX_L2_BLOCK_SIZE);
-    assert(MATRIX_L2_BLOCK_SIZE >= MATRIX_L1_BLOCK_SIZE);
-    assert(MATRIX_L1_BLOCK_SIZE >= MATRIX_MIN_BLOCK_SIZE);
-    assert(MATRIX_MAX_BLOCK_SIZE >= MATRIX_L3_BLOCK_SIZE);
+    EXPECT_TRUE(MATRIX_L3_BLOCK_SIZE >= MATRIX_L2_BLOCK_SIZE);
+    EXPECT_TRUE(MATRIX_L2_BLOCK_SIZE >= MATRIX_L1_BLOCK_SIZE);
+    EXPECT_TRUE(MATRIX_L1_BLOCK_SIZE >= MATRIX_MIN_BLOCK_SIZE);
+    EXPECT_TRUE(MATRIX_MAX_BLOCK_SIZE >= MATRIX_L3_BLOCK_SIZE);
 
     // Test SIMD register widths (doubles per register)
-    assert(AVX512_DOUBLES == 8);
-    assert(AVX_DOUBLES == 4);
-    assert(AVX2_DOUBLES == 4);
-    assert(SSE_DOUBLES == 2);
-    assert(NEON_DOUBLES == 2);
-    assert(SCALAR_DOUBLES == 1);
+    EXPECT_TRUE(AVX512_DOUBLES == 8);
+    EXPECT_TRUE(AVX_DOUBLES == 4);
+    EXPECT_TRUE(AVX2_DOUBLES == 4);
+    EXPECT_TRUE(SSE_DOUBLES == 2);
+    EXPECT_TRUE(NEON_DOUBLES == 2);
+    EXPECT_TRUE(SCALAR_DOUBLES == 1);
 
     // Test register width hierarchy
-    assert(AVX512_DOUBLES >= AVX_DOUBLES);
-    assert(AVX_DOUBLES >= SSE_DOUBLES);
-    assert(SSE_DOUBLES >= SCALAR_DOUBLES);
+    EXPECT_TRUE(AVX512_DOUBLES >= AVX_DOUBLES);
+    EXPECT_TRUE(AVX_DOUBLES >= SSE_DOUBLES);
+    EXPECT_TRUE(SSE_DOUBLES >= SCALAR_DOUBLES);
 
     // Test loop unrolling factors
-    assert(AVX512_UNROLL == 4);
-    assert(AVX_UNROLL == 2);
-    assert(SSE_UNROLL == 2);
-    assert(NEON_UNROLL == 2);
-    assert(SCALAR_UNROLL == 1);
+    EXPECT_TRUE(AVX512_UNROLL == 4);
+    EXPECT_TRUE(AVX_UNROLL == 2);
+    EXPECT_TRUE(SSE_UNROLL == 2);
+    EXPECT_TRUE(NEON_UNROLL == 2);
+    EXPECT_TRUE(SCALAR_UNROLL == 1);
 
     // Test optimization thresholds
-    assert(OPT_MEDIUM_DATASET_MIN_SIZE == 32);
-    assert(OPT_ALIGNMENT_BENEFIT_THRESHOLD == 32);
-    assert(OPT_AVX512_MIN_ALIGNED_SIZE == 8);
-    assert(OPT_APPLE_SILICON_AGGRESSIVE_THRESHOLD == 6);
-    assert(OPT_AVX512_SMALL_BENEFIT_THRESHOLD == 4);
+    EXPECT_TRUE(OPT_MEDIUM_DATASET_MIN_SIZE == 32);
+    EXPECT_TRUE(OPT_ALIGNMENT_BENEFIT_THRESHOLD == 32);
+    EXPECT_TRUE(OPT_AVX512_MIN_ALIGNED_SIZE == 8);
+    EXPECT_TRUE(OPT_APPLE_SILICON_AGGRESSIVE_THRESHOLD == 6);
+    EXPECT_TRUE(OPT_AVX512_SMALL_BENEFIT_THRESHOLD == 4);
 
     std::cout << "   ✓ SIMD constants tests passed" << std::endl;
 }
@@ -221,26 +221,26 @@ void test_platform_optimizations() {
     [[maybe_unused]] size_t min_parallel_elements = get_min_parallel_elements();
     [[maybe_unused]] size_t optimal_grain_size = get_optimal_grain_size();
 
-    assert(simd_block_size > 0);
-    assert(alignment >= 16);  // At least 16-byte alignment for SIMD
-    assert(min_simd_size > 0);
-    assert(min_parallel_elements > 0);
-    assert(optimal_grain_size > 0);
+    EXPECT_TRUE(simd_block_size > 0);
+    EXPECT_TRUE(alignment >= 16);  // At least 16-byte alignment for SIMD
+    EXPECT_TRUE(min_simd_size > 0);
+    EXPECT_TRUE(min_parallel_elements > 0);
+    EXPECT_TRUE(optimal_grain_size > 0);
 
     // Test alignment is power of 2
-    assert((alignment & (alignment - 1)) == 0);
+    EXPECT_TRUE((alignment & (alignment - 1)) == 0);
 
     // Test platform-specific thresholds
     [[maybe_unused]] auto cache_thresholds = get_cache_thresholds();
-    assert(cache_thresholds.l1_optimal_size > 0);
-    assert(cache_thresholds.l2_optimal_size > cache_thresholds.l1_optimal_size);
+    EXPECT_TRUE(cache_thresholds.l1_optimal_size > 0);
+    EXPECT_TRUE(cache_thresholds.l2_optimal_size > cache_thresholds.l1_optimal_size);
 #ifdef __APPLE__
     // Assume no L3 cache on Apple Silicon
-    assert(cache_thresholds.l3_optimal_size >= cache_thresholds.l2_optimal_size);
+    EXPECT_TRUE(cache_thresholds.l3_optimal_size >= cache_thresholds.l2_optimal_size);
 #else
-    assert(cache_thresholds.l3_optimal_size > cache_thresholds.l2_optimal_size);
+    EXPECT_TRUE(cache_thresholds.l3_optimal_size > cache_thresholds.l2_optimal_size);
 #endif
-    assert(cache_thresholds.blocking_size > 0);
+    EXPECT_TRUE(cache_thresholds.blocking_size > 0);
 
     // Test transcendental support detection
     bool supports_fast_transcendental = stats::arch::supports_fast_transcendental();
@@ -254,54 +254,54 @@ void test_parallel_constants() {
     using namespace stats::arch::parallel;
 
     // Test parallel processing constants (using accessor functions)
-    assert(stats::arch::get_min_elements_for_parallel() > 0);
-    assert(stats::arch::get_min_elements_for_distribution_parallel() > 0);
-    assert(stats::arch::get_default_grain_size() > 0);
-    assert(stats::arch::get_simple_operation_grain_size() > 0);
-    assert(MIN_DATASET_SIZE_FOR_PARALLEL > 0);
-    assert(MIN_BOOTSTRAP_SAMPLES_FOR_PARALLEL > 0);
-    assert(MIN_TOTAL_WORK_FOR_MONTE_CARLO_PARALLEL > 0);
-    assert(stats::arch::get_monte_carlo_grain_size() > 0);
-    assert(stats::arch::get_max_grain_size() > 0);
-    assert(MIN_WORK_PER_THREAD > 0);
-    assert(SAMPLE_BATCH_SIZE > 0);
-    assert(MIN_MATRIX_SIZE_FOR_PARALLEL > 0);
-    assert(MIN_ITERATIONS_FOR_PARALLEL > 0);
+    EXPECT_TRUE(stats::arch::get_min_elements_for_parallel() > 0);
+    EXPECT_TRUE(stats::arch::get_min_elements_for_distribution_parallel() > 0);
+    EXPECT_TRUE(stats::arch::get_default_grain_size() > 0);
+    EXPECT_TRUE(stats::arch::get_simple_operation_grain_size() > 0);
+    EXPECT_TRUE(MIN_DATASET_SIZE_FOR_PARALLEL > 0);
+    EXPECT_TRUE(MIN_BOOTSTRAP_SAMPLES_FOR_PARALLEL > 0);
+    EXPECT_TRUE(MIN_TOTAL_WORK_FOR_MONTE_CARLO_PARALLEL > 0);
+    EXPECT_TRUE(stats::arch::get_monte_carlo_grain_size() > 0);
+    EXPECT_TRUE(stats::arch::get_max_grain_size() > 0);
+    EXPECT_TRUE(MIN_WORK_PER_THREAD > 0);
+    EXPECT_TRUE(SAMPLE_BATCH_SIZE > 0);
+    EXPECT_TRUE(MIN_MATRIX_SIZE_FOR_PARALLEL > 0);
+    EXPECT_TRUE(MIN_ITERATIONS_FOR_PARALLEL > 0);
 
     // Test logical relationships (using accessor functions)
-    assert(stats::arch::get_min_elements_for_distribution_parallel() <=
+    EXPECT_TRUE(stats::arch::get_min_elements_for_distribution_parallel() <=
            stats::arch::get_min_elements_for_parallel());
-    assert(stats::arch::get_simple_operation_grain_size() <= stats::arch::get_default_grain_size());
-    assert(stats::arch::get_monte_carlo_grain_size() <= stats::arch::get_max_grain_size());
+    EXPECT_TRUE(stats::arch::get_simple_operation_grain_size() <= stats::arch::get_default_grain_size());
+    EXPECT_TRUE(stats::arch::get_monte_carlo_grain_size() <= stats::arch::get_max_grain_size());
 
     // Test SSE parallel constants
-    assert(sse::MIN_ELEMENTS_FOR_PARALLEL == 2048);
-    assert(sse::MIN_ELEMENTS_FOR_DISTRIBUTION_PARALLEL == 1024);
-    assert(sse::MIN_ELEMENTS_FOR_SIMPLE_DISTRIBUTION_PARALLEL == 16384);
-    assert(sse::DEFAULT_GRAIN_SIZE == 128);
-    assert(sse::SIMPLE_OPERATION_GRAIN_SIZE == 64);
-    assert(sse::COMPLEX_OPERATION_GRAIN_SIZE == 256);
-    assert(sse::MONTE_CARLO_GRAIN_SIZE == 32);
-    assert(sse::MAX_GRAIN_SIZE == 2048);
+    EXPECT_TRUE(sse::MIN_ELEMENTS_FOR_PARALLEL == 2048);
+    EXPECT_TRUE(sse::MIN_ELEMENTS_FOR_DISTRIBUTION_PARALLEL == 1024);
+    EXPECT_TRUE(sse::MIN_ELEMENTS_FOR_SIMPLE_DISTRIBUTION_PARALLEL == 16384);
+    EXPECT_TRUE(sse::DEFAULT_GRAIN_SIZE == 128);
+    EXPECT_TRUE(sse::SIMPLE_OPERATION_GRAIN_SIZE == 64);
+    EXPECT_TRUE(sse::COMPLEX_OPERATION_GRAIN_SIZE == 256);
+    EXPECT_TRUE(sse::MONTE_CARLO_GRAIN_SIZE == 32);
+    EXPECT_TRUE(sse::MAX_GRAIN_SIZE == 2048);
 
     // Test AVX parallel constants
-    assert(avx::MIN_ELEMENTS_FOR_PARALLEL == 4096);
-    assert(avx::MIN_ELEMENTS_FOR_DISTRIBUTION_PARALLEL == 2048);
-    assert(avx::MIN_ELEMENTS_FOR_SIMPLE_DISTRIBUTION_PARALLEL == 32768);
-    assert(avx::DEFAULT_GRAIN_SIZE == 256);
-    assert(avx::SIMPLE_OPERATION_GRAIN_SIZE == 128);
-    assert(avx::COMPLEX_OPERATION_GRAIN_SIZE == 512);
-    assert(avx::MONTE_CARLO_GRAIN_SIZE == 64);
-    assert(avx::MAX_GRAIN_SIZE == 4096);
+    EXPECT_TRUE(avx::MIN_ELEMENTS_FOR_PARALLEL == 4096);
+    EXPECT_TRUE(avx::MIN_ELEMENTS_FOR_DISTRIBUTION_PARALLEL == 2048);
+    EXPECT_TRUE(avx::MIN_ELEMENTS_FOR_SIMPLE_DISTRIBUTION_PARALLEL == 32768);
+    EXPECT_TRUE(avx::DEFAULT_GRAIN_SIZE == 256);
+    EXPECT_TRUE(avx::SIMPLE_OPERATION_GRAIN_SIZE == 128);
+    EXPECT_TRUE(avx::COMPLEX_OPERATION_GRAIN_SIZE == 512);
+    EXPECT_TRUE(avx::MONTE_CARLO_GRAIN_SIZE == 64);
+    EXPECT_TRUE(avx::MAX_GRAIN_SIZE == 4096);
 
     // Test architecture hierarchy - AVX should have larger thresholds than SSE
-    assert(avx::MIN_ELEMENTS_FOR_PARALLEL >= sse::MIN_ELEMENTS_FOR_PARALLEL);
-    assert(avx::DEFAULT_GRAIN_SIZE >= sse::DEFAULT_GRAIN_SIZE);
-    assert(avx::MAX_GRAIN_SIZE >= sse::MAX_GRAIN_SIZE);
+    EXPECT_TRUE(avx::MIN_ELEMENTS_FOR_PARALLEL >= sse::MIN_ELEMENTS_FOR_PARALLEL);
+    EXPECT_TRUE(avx::DEFAULT_GRAIN_SIZE >= sse::DEFAULT_GRAIN_SIZE);
+    EXPECT_TRUE(avx::MAX_GRAIN_SIZE >= sse::MAX_GRAIN_SIZE);
 
     // Test adaptive functions
-    assert(stats::arch::get_min_elements_for_parallel() > 0);
-    assert(stats::arch::get_default_grain_size() > 0);
+    EXPECT_TRUE(stats::arch::get_min_elements_for_parallel() > 0);
+    EXPECT_TRUE(stats::arch::get_default_grain_size() > 0);
 
     std::cout << "   ✓ Parallel constants tests passed" << std::endl;
 }
@@ -310,63 +310,63 @@ void test_statistical_critical_values() {
     using namespace stats::detail;
 
     // Standard normal distribution critical values
-    assert(std::abs(Z_95 - 1.96) < 0.001);
-    assert(std::abs(Z_99 - 2.576) < 0.001);
-    assert(std::abs(Z_90 - 1.645) < 0.001);
-    assert(std::abs(Z_999 - 3.291) < 0.001);
-    assert(std::abs(Z_95_ONE_TAIL - 1.645) < 0.001);
-    assert(std::abs(Z_99_ONE_TAIL - 2.326) < 0.001);
+    EXPECT_TRUE(std::abs(Z_95 - 1.96) < 0.001);
+    EXPECT_TRUE(std::abs(Z_99 - 2.576) < 0.001);
+    EXPECT_TRUE(std::abs(Z_90 - 1.645) < 0.001);
+    EXPECT_TRUE(std::abs(Z_999 - 3.291) < 0.001);
+    EXPECT_TRUE(std::abs(Z_95_ONE_TAIL - 1.645) < 0.001);
+    EXPECT_TRUE(std::abs(Z_99_ONE_TAIL - 2.326) < 0.001);
 
     // Test ordering of critical values
-    assert(Z_90 < Z_95);
-    assert(Z_95 < Z_99);
-    assert(Z_99 < Z_999);
+    EXPECT_TRUE(Z_90 < Z_95);
+    EXPECT_TRUE(Z_95 < Z_99);
+    EXPECT_TRUE(Z_99 < Z_999);
 
     // Test t-distribution critical values
-    assert(T_95_DF_1 > T_95_DF_2);
-    assert(T_95_DF_2 > T_95_DF_3);
-    assert(T_95_DF_INF == Z_95);
+    EXPECT_TRUE(T_95_DF_1 > T_95_DF_2);
+    EXPECT_TRUE(T_95_DF_2 > T_95_DF_3);
+    EXPECT_TRUE(T_95_DF_INF == Z_95);
 
     // Test chi-square critical values
-    assert(CHI2_95_DF_1 < CHI2_95_DF_2);
-    assert(CHI2_95_DF_2 < CHI2_95_DF_3);
-    assert(CHI2_99_DF_1 > CHI2_95_DF_1);
+    EXPECT_TRUE(CHI2_95_DF_1 < CHI2_95_DF_2);
+    EXPECT_TRUE(CHI2_95_DF_2 < CHI2_95_DF_3);
+    EXPECT_TRUE(CHI2_99_DF_1 > CHI2_95_DF_1);
 
     // Test F-distribution critical values
-    assert(F_95_DF_1_1 > F_95_DF_1_5);
-    assert(F_99_DF_1_1 > F_95_DF_1_1);
+    EXPECT_TRUE(F_95_DF_1_1 > F_95_DF_1_5);
+    EXPECT_TRUE(F_99_DF_1_1 > F_95_DF_1_1);
 
     // Test threshold values
-    assert(ALPHA_001 < ALPHA_01);
-    assert(ALPHA_01 < ALPHA_05);
-    assert(ALPHA_05 < ALPHA_10);
+    EXPECT_TRUE(ALPHA_001 < ALPHA_01);
+    EXPECT_TRUE(ALPHA_01 < ALPHA_05);
+    EXPECT_TRUE(ALPHA_05 < ALPHA_10);
 
-    assert(CONFIDENCE_90 < CONFIDENCE_95);
-    assert(CONFIDENCE_95 < CONFIDENCE_99);
-    assert(CONFIDENCE_99 < CONFIDENCE_999);
+    EXPECT_TRUE(CONFIDENCE_90 < CONFIDENCE_95);
+    EXPECT_TRUE(CONFIDENCE_95 < CONFIDENCE_99);
+    EXPECT_TRUE(CONFIDENCE_99 < CONFIDENCE_999);
 
     // Test effect size thresholds
-    assert(SMALL_EFFECT < MEDIUM_EFFECT);
-    assert(MEDIUM_EFFECT < LARGE_EFFECT);
+    EXPECT_TRUE(SMALL_EFFECT < MEDIUM_EFFECT);
+    EXPECT_TRUE(MEDIUM_EFFECT < LARGE_EFFECT);
 
     // Test correlation strength thresholds
-    assert(WEAK_CORRELATION < MODERATE_CORRELATION);
-    assert(MODERATE_CORRELATION < STRONG_CORRELATION);
+    EXPECT_TRUE(WEAK_CORRELATION < MODERATE_CORRELATION);
+    EXPECT_TRUE(MODERATE_CORRELATION < STRONG_CORRELATION);
 
     // Test Kolmogorov-Smirnov critical values
-    assert(KS_05_N_5 > KS_05_N_10);
-    assert(KS_05_N_10 > KS_05_N_20);
-    assert(KS_01_N_5 > KS_05_N_5);
+    EXPECT_TRUE(KS_05_N_5 > KS_05_N_10);
+    EXPECT_TRUE(KS_05_N_10 > KS_05_N_20);
+    EXPECT_TRUE(KS_01_N_5 > KS_05_N_5);
 
     // Test Anderson-Darling critical values
-    assert(AD_01 > AD_05);
-    assert(AD_05 > AD_10);
-    assert(AD_10 > AD_15);
+    EXPECT_TRUE(AD_01 > AD_05);
+    EXPECT_TRUE(AD_05 > AD_10);
+    EXPECT_TRUE(AD_10 > AD_15);
 
     // Test Shapiro-Wilk critical values
-    assert(SW_05_N_10 < SW_05_N_20);
-    assert(SW_05_N_20 < SW_05_N_30);
-    assert(SW_01_N_10 < SW_05_N_10);
+    EXPECT_TRUE(SW_05_N_10 < SW_05_N_20);
+    EXPECT_TRUE(SW_05_N_20 < SW_05_N_30);
+    EXPECT_TRUE(SW_01_N_10 < SW_05_N_10);
 
     std::cout << "   ✓ Statistical critical values tests passed" << std::endl;
 }
@@ -375,20 +375,20 @@ void test_threshold_constants() {
     using namespace stats::detail;
 
     // Test scale factor bounds
-    assert(MIN_SCALE_FACTOR > 0.0);
-    assert(MAX_SCALE_FACTOR > MIN_SCALE_FACTOR);
-    assert(MIN_SCALE_FACTOR == 1.0e-100);
-    assert(MAX_SCALE_FACTOR == 1.0e100);
+    EXPECT_TRUE(MIN_SCALE_FACTOR > 0.0);
+    EXPECT_TRUE(MAX_SCALE_FACTOR > MIN_SCALE_FACTOR);
+    EXPECT_TRUE(MIN_SCALE_FACTOR == 1.0e-100);
+    EXPECT_TRUE(MAX_SCALE_FACTOR == 1.0e100);
 
     // Test log-space threshold
-    assert(LOG_SPACE_THRESHOLD > 0.0);
-    assert(LOG_SPACE_THRESHOLD == 1.0e-50);
+    EXPECT_TRUE(LOG_SPACE_THRESHOLD > 0.0);
+    EXPECT_TRUE(LOG_SPACE_THRESHOLD == 1.0e-50);
 
     // Test distribution parameter bounds
-    assert(MIN_DISTRIBUTION_PARAMETER > 0.0);
-    assert(MAX_DISTRIBUTION_PARAMETER > MIN_DISTRIBUTION_PARAMETER);
-    assert(MIN_DISTRIBUTION_PARAMETER == 1.0e-6);
-    assert(MAX_DISTRIBUTION_PARAMETER == 1.0e6);
+    EXPECT_TRUE(MIN_DISTRIBUTION_PARAMETER > 0.0);
+    EXPECT_TRUE(MAX_DISTRIBUTION_PARAMETER > MIN_DISTRIBUTION_PARAMETER);
+    EXPECT_TRUE(MIN_DISTRIBUTION_PARAMETER == 1.0e-6);
+    EXPECT_TRUE(MAX_DISTRIBUTION_PARAMETER == 1.0e6);
 
     std::cout << "   ✓ Threshold constants tests passed" << std::endl;
 }
@@ -401,28 +401,28 @@ void test_benchmark_constants() {
     using namespace stats::detail;
 
     // Test benchmark iteration constants
-    assert(DEFAULT_ITERATIONS > 0);
-    assert(DEFAULT_WARMUP_RUNS > 0);
-    assert(MIN_ITERATIONS > 0);
-    assert(MIN_WARMUP_RUNS > 0);
-    assert(MAX_ITERATIONS >= DEFAULT_ITERATIONS);
-    assert(MAX_WARMUP_RUNS >= DEFAULT_WARMUP_RUNS);
-    assert(DEFAULT_ITERATIONS >= MIN_ITERATIONS);
-    assert(DEFAULT_WARMUP_RUNS >= MIN_WARMUP_RUNS);
+    EXPECT_TRUE(DEFAULT_ITERATIONS > 0);
+    EXPECT_TRUE(DEFAULT_WARMUP_RUNS > 0);
+    EXPECT_TRUE(MIN_ITERATIONS > 0);
+    EXPECT_TRUE(MIN_WARMUP_RUNS > 0);
+    EXPECT_TRUE(MAX_ITERATIONS >= DEFAULT_ITERATIONS);
+    EXPECT_TRUE(MAX_WARMUP_RUNS >= DEFAULT_WARMUP_RUNS);
+    EXPECT_TRUE(DEFAULT_ITERATIONS >= MIN_ITERATIONS);
+    EXPECT_TRUE(DEFAULT_WARMUP_RUNS >= MIN_WARMUP_RUNS);
 
     // Test execution time thresholds
-    assert(MIN_EXECUTION_TIME > 0.0);
-    assert(MAX_EXECUTION_TIME > MIN_EXECUTION_TIME);
-    assert(MIN_EXECUTION_TIME == 1.0e-9);
-    assert(MAX_EXECUTION_TIME == 3600.0);
+    EXPECT_TRUE(MIN_EXECUTION_TIME > 0.0);
+    EXPECT_TRUE(MAX_EXECUTION_TIME > MIN_EXECUTION_TIME);
+    EXPECT_TRUE(MIN_EXECUTION_TIME == 1.0e-9);
+    EXPECT_TRUE(MAX_EXECUTION_TIME == 3600.0);
 
     // Test statistical thresholds
-    assert(PERFORMANCE_SIGNIFICANCE_THRESHOLD > 0.0);
-    assert(PERFORMANCE_SIGNIFICANCE_THRESHOLD <= 1.0);
-    assert(CV_THRESHOLD > 0.0);
-    assert(CV_THRESHOLD <= 1.0);
-    assert(PERFORMANCE_SIGNIFICANCE_THRESHOLD == 0.05);
-    assert(CV_THRESHOLD == 0.1);
+    EXPECT_TRUE(PERFORMANCE_SIGNIFICANCE_THRESHOLD > 0.0);
+    EXPECT_TRUE(PERFORMANCE_SIGNIFICANCE_THRESHOLD <= 1.0);
+    EXPECT_TRUE(CV_THRESHOLD > 0.0);
+    EXPECT_TRUE(CV_THRESHOLD <= 1.0);
+    EXPECT_TRUE(PERFORMANCE_SIGNIFICANCE_THRESHOLD == 0.05);
+    EXPECT_TRUE(CV_THRESHOLD == 0.1);
 
     std::cout << "   ✓ Benchmark constants tests passed" << std::endl;
 }
@@ -431,29 +431,29 @@ void test_robust_constants() {
     using namespace stats::detail;
 
     // Test MAD scaling factor
-    assert(MAD_SCALING_FACTOR > 0.0);
-    assert(std::abs(MAD_SCALING_FACTOR - 1.4826) < 1e-4);
+    EXPECT_TRUE(MAD_SCALING_FACTOR > 0.0);
+    EXPECT_TRUE(std::abs(MAD_SCALING_FACTOR - 1.4826) < 1e-4);
 
     // Test M-estimator tuning constants
-    assert(TUNING_HUBER_DEFAULT > 0.0);
-    assert(TUNING_TUKEY_DEFAULT > 0.0);
-    assert(TUNING_HAMPEL_A > 0.0);
-    assert(TUNING_HAMPEL_B > TUNING_HAMPEL_A);
-    assert(TUNING_HAMPEL_C > TUNING_HAMPEL_B);
+    EXPECT_TRUE(TUNING_HUBER_DEFAULT > 0.0);
+    EXPECT_TRUE(TUNING_TUKEY_DEFAULT > 0.0);
+    EXPECT_TRUE(TUNING_HAMPEL_A > 0.0);
+    EXPECT_TRUE(TUNING_HAMPEL_B > TUNING_HAMPEL_A);
+    EXPECT_TRUE(TUNING_HAMPEL_C > TUNING_HAMPEL_B);
 
     // Test specific values
-    assert(std::abs(TUNING_HUBER_DEFAULT - 1.345) < 1e-3);
-    assert(std::abs(TUNING_TUKEY_DEFAULT - 4.685) < 1e-3);
-    assert(std::abs(TUNING_HAMPEL_A - 1.7) < 1e-1);
-    assert(std::abs(TUNING_HAMPEL_B - 3.4) < 1e-1);
-    assert(std::abs(TUNING_HAMPEL_C - 8.5) < 1e-1);
+    EXPECT_TRUE(std::abs(TUNING_HUBER_DEFAULT - 1.345) < 1e-3);
+    EXPECT_TRUE(std::abs(TUNING_TUKEY_DEFAULT - 4.685) < 1e-3);
+    EXPECT_TRUE(std::abs(TUNING_HAMPEL_A - 1.7) < 1e-1);
+    EXPECT_TRUE(std::abs(TUNING_HAMPEL_B - 3.4) < 1e-1);
+    EXPECT_TRUE(std::abs(TUNING_HAMPEL_C - 8.5) < 1e-1);
 
     // Test iteration and convergence parameters
-    assert(MAX_ROBUST_ITERATIONS > 0);
-    assert(ROBUST_CONVERGENCE_TOLERANCE > 0.0);
-    assert(MIN_ROBUST_SCALE > 0.0);
-    assert(ROBUST_CONVERGENCE_TOLERANCE == 1.0e-6);
-    assert(MIN_ROBUST_SCALE == 1.0e-8);
+    EXPECT_TRUE(MAX_ROBUST_ITERATIONS > 0);
+    EXPECT_TRUE(ROBUST_CONVERGENCE_TOLERANCE > 0.0);
+    EXPECT_TRUE(MIN_ROBUST_SCALE > 0.0);
+    EXPECT_TRUE(ROBUST_CONVERGENCE_TOLERANCE == 1.0e-6);
+    EXPECT_TRUE(MIN_ROBUST_SCALE == 1.0e-8);
 
     std::cout << "   ✓ Robust constants tests passed" << std::endl;
 }
@@ -462,41 +462,41 @@ void test_goodness_of_fit_constants() {
     using namespace stats::detail;
 
     // Test Kolmogorov-Smirnov critical values (α = 0.05)
-    assert(KS_05_N_5 > KS_05_N_10);
-    assert(KS_05_N_10 > KS_05_N_15);
-    assert(KS_05_N_15 > KS_05_N_20);
-    assert(KS_05_N_20 > KS_05_N_25);
-    assert(KS_05_N_25 > KS_05_N_30);
-    assert(KS_05_N_30 > KS_05_N_50);
-    assert(KS_05_N_50 > KS_05_N_100);
+    EXPECT_TRUE(KS_05_N_5 > KS_05_N_10);
+    EXPECT_TRUE(KS_05_N_10 > KS_05_N_15);
+    EXPECT_TRUE(KS_05_N_15 > KS_05_N_20);
+    EXPECT_TRUE(KS_05_N_20 > KS_05_N_25);
+    EXPECT_TRUE(KS_05_N_25 > KS_05_N_30);
+    EXPECT_TRUE(KS_05_N_30 > KS_05_N_50);
+    EXPECT_TRUE(KS_05_N_50 > KS_05_N_100);
 
     // Test Kolmogorov-Smirnov critical values (α = 0.01)
-    assert(KS_01_N_5 > KS_01_N_10);
-    assert(KS_01_N_10 > KS_01_N_15);
-    assert(KS_01_N_15 > KS_01_N_20);
+    EXPECT_TRUE(KS_01_N_5 > KS_01_N_10);
+    EXPECT_TRUE(KS_01_N_10 > KS_01_N_15);
+    EXPECT_TRUE(KS_01_N_15 > KS_01_N_20);
 
     // Test that 0.01 values are larger than 0.05 values
-    assert(KS_01_N_5 > KS_05_N_5);
-    assert(KS_01_N_10 > KS_05_N_10);
-    assert(KS_01_N_20 > KS_05_N_20);
+    EXPECT_TRUE(KS_01_N_5 > KS_05_N_5);
+    EXPECT_TRUE(KS_01_N_10 > KS_05_N_10);
+    EXPECT_TRUE(KS_01_N_20 > KS_05_N_20);
 
     // Test Anderson-Darling critical values (increasing with significance)
-    assert(AD_01 > AD_025);
-    assert(AD_025 > AD_05);
-    assert(AD_05 > AD_10);
-    assert(AD_10 > AD_15);
+    EXPECT_TRUE(AD_01 > AD_025);
+    EXPECT_TRUE(AD_025 > AD_05);
+    EXPECT_TRUE(AD_05 > AD_10);
+    EXPECT_TRUE(AD_10 > AD_15);
 
     // Test Shapiro-Wilk critical values (increasing with sample size)
-    assert(SW_05_N_50 > SW_05_N_30);
-    assert(SW_05_N_30 > SW_05_N_25);
-    assert(SW_05_N_25 > SW_05_N_20);
-    assert(SW_05_N_20 > SW_05_N_15);
-    assert(SW_05_N_15 > SW_05_N_10);
+    EXPECT_TRUE(SW_05_N_50 > SW_05_N_30);
+    EXPECT_TRUE(SW_05_N_30 > SW_05_N_25);
+    EXPECT_TRUE(SW_05_N_25 > SW_05_N_20);
+    EXPECT_TRUE(SW_05_N_20 > SW_05_N_15);
+    EXPECT_TRUE(SW_05_N_15 > SW_05_N_10);
 
     // Test that 0.01 values are smaller than 0.05 values (for Shapiro-Wilk)
-    assert(SW_01_N_10 < SW_05_N_10);
-    assert(SW_01_N_20 < SW_05_N_20);
-    assert(SW_01_N_30 < SW_05_N_30);
+    EXPECT_TRUE(SW_01_N_10 < SW_05_N_10);
+    EXPECT_TRUE(SW_01_N_20 < SW_05_N_20);
+    EXPECT_TRUE(SW_01_N_30 < SW_05_N_30);
 
     std::cout << "   ✓ Goodness-of-fit constants tests passed" << std::endl;
 }
@@ -514,66 +514,66 @@ void test_test_infrastructure_constants() {
     using namespace stats::tests::constants;
 
     // Test precision tolerances
-    assert(DEFAULT_TOLERANCE > 0.0);
-    assert(HIGH_PRECISION_TOLERANCE > 0.0);
-    assert(ULTRA_HIGH_PRECISION_TOLERANCE > 0.0);
-    assert(RELAXED_TOLERANCE > 0.0);
-    assert(STRICT_TOLERANCE > 0.0);
-    assert(DEFAULT_TOLERANCE > HIGH_PRECISION_TOLERANCE);
-    assert(HIGH_PRECISION_TOLERANCE > ULTRA_HIGH_PRECISION_TOLERANCE);
-    assert(RELAXED_TOLERANCE > DEFAULT_TOLERANCE);
-    assert(DEFAULT_TOLERANCE > STRICT_TOLERANCE);
+    EXPECT_TRUE(DEFAULT_TOLERANCE > 0.0);
+    EXPECT_TRUE(HIGH_PRECISION_TOLERANCE > 0.0);
+    EXPECT_TRUE(ULTRA_HIGH_PRECISION_TOLERANCE > 0.0);
+    EXPECT_TRUE(RELAXED_TOLERANCE > 0.0);
+    EXPECT_TRUE(STRICT_TOLERANCE > 0.0);
+    EXPECT_TRUE(DEFAULT_TOLERANCE > HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(HIGH_PRECISION_TOLERANCE > ULTRA_HIGH_PRECISION_TOLERANCE);
+    EXPECT_TRUE(RELAXED_TOLERANCE > DEFAULT_TOLERANCE);
+    EXPECT_TRUE(DEFAULT_TOLERANCE > STRICT_TOLERANCE);
 
     // Test SIMD and parallel comparison tolerances
-    assert(SIMD_COMPARISON_TOLERANCE > 0.0);
-    assert(PARALLEL_COMPARISON_TOLERANCE > 0.0);
-    assert(STATISTICAL_TOLERANCE > 0.0);
-    assert(GOF_TOLERANCE > 0.0);
+    EXPECT_TRUE(SIMD_COMPARISON_TOLERANCE > 0.0);
+    EXPECT_TRUE(PARALLEL_COMPARISON_TOLERANCE > 0.0);
+    EXPECT_TRUE(STATISTICAL_TOLERANCE > 0.0);
+    EXPECT_TRUE(GOF_TOLERANCE > 0.0);
 
     // Test performance expectations
-    assert(SIMD_SPEEDUP_MIN_EXPECTED > 1.0);
-    assert(PARALLEL_SPEEDUP_MIN_EXPECTED > 1.0);
-    assert(SIMD_SPEEDUP_MIN_EXPECTED == 1.5);
-    assert(PARALLEL_SPEEDUP_MIN_EXPECTED == 2.0);
+    EXPECT_TRUE(SIMD_SPEEDUP_MIN_EXPECTED > 1.0);
+    EXPECT_TRUE(PARALLEL_SPEEDUP_MIN_EXPECTED > 1.0);
+    EXPECT_TRUE(SIMD_SPEEDUP_MIN_EXPECTED == 1.5);
+    EXPECT_TRUE(PARALLEL_SPEEDUP_MIN_EXPECTED == 2.0);
 
     // Test benchmark parameters
-    assert(DEFAULT_BENCHMARK_ITERATIONS > 0);
-    assert(SMALL_BENCHMARK_ITERATIONS > 0);
-    assert(LARGE_BENCHMARK_ITERATIONS > DEFAULT_BENCHMARK_ITERATIONS);
-    assert(BENCHMARK_WARMUP_ITERATIONS > 0);
-    assert(MAX_BENCHMARK_VARIANCE > 0.0);
-    assert(MAX_BENCHMARK_VARIANCE <= 1.0);
-    assert(MIN_BENCHMARK_MEASUREMENTS > 0);
+    EXPECT_TRUE(DEFAULT_BENCHMARK_ITERATIONS > 0);
+    EXPECT_TRUE(SMALL_BENCHMARK_ITERATIONS > 0);
+    EXPECT_TRUE(LARGE_BENCHMARK_ITERATIONS > DEFAULT_BENCHMARK_ITERATIONS);
+    EXPECT_TRUE(BENCHMARK_WARMUP_ITERATIONS > 0);
+    EXPECT_TRUE(MAX_BENCHMARK_VARIANCE > 0.0);
+    EXPECT_TRUE(MAX_BENCHMARK_VARIANCE <= 1.0);
+    EXPECT_TRUE(MIN_BENCHMARK_MEASUREMENTS > 0);
 
     // Test dataset sizes
-    assert(SMALL_DATASET_SIZE > 0);
-    assert(MEDIUM_DATASET_SIZE > SMALL_DATASET_SIZE);
-    assert(LARGE_DATASET_SIZE > MEDIUM_DATASET_SIZE);
-    assert(EXTRA_LARGE_DATASET_SIZE > LARGE_DATASET_SIZE);
+    EXPECT_TRUE(SMALL_DATASET_SIZE > 0);
+    EXPECT_TRUE(MEDIUM_DATASET_SIZE > SMALL_DATASET_SIZE);
+    EXPECT_TRUE(LARGE_DATASET_SIZE > MEDIUM_DATASET_SIZE);
+    EXPECT_TRUE(EXTRA_LARGE_DATASET_SIZE > LARGE_DATASET_SIZE);
 
     // Test batch sizes
-    assert(SMALL_BATCH_SIZE > 0);
-    assert(MEDIUM_BATCH_SIZE > SMALL_BATCH_SIZE);
-    assert(LARGE_BATCH_SIZE > MEDIUM_BATCH_SIZE);
+    EXPECT_TRUE(SMALL_BATCH_SIZE > 0);
+    EXPECT_TRUE(MEDIUM_BATCH_SIZE > SMALL_BATCH_SIZE);
+    EXPECT_TRUE(LARGE_BATCH_SIZE > MEDIUM_BATCH_SIZE);
 
     // Test statistical test parameters
-    assert(DEFAULT_ALPHA > 0.0 && DEFAULT_ALPHA < 1.0);
-    assert(STRICT_ALPHA > 0.0 && STRICT_ALPHA < DEFAULT_ALPHA);
-    assert(RELAXED_ALPHA > DEFAULT_ALPHA && RELAXED_ALPHA < 1.0);
-    assert(DEFAULT_CONFIDENCE_LEVEL > 0.0 && DEFAULT_CONFIDENCE_LEVEL < 1.0);
+    EXPECT_TRUE(DEFAULT_ALPHA > 0.0 && DEFAULT_ALPHA < 1.0);
+    EXPECT_TRUE(STRICT_ALPHA > 0.0 && STRICT_ALPHA < DEFAULT_ALPHA);
+    EXPECT_TRUE(RELAXED_ALPHA > DEFAULT_ALPHA && RELAXED_ALPHA < 1.0);
+    EXPECT_TRUE(DEFAULT_CONFIDENCE_LEVEL > 0.0 && DEFAULT_CONFIDENCE_LEVEL < 1.0);
 
     // Test bootstrap parameters
-    assert(DEFAULT_BOOTSTRAP_SAMPLES > MIN_BOOTSTRAP_SAMPLES);
-    assert(MAX_BOOTSTRAP_SAMPLES > DEFAULT_BOOTSTRAP_SAMPLES);
-    assert(DEFAULT_CV_FOLDS > 0);
-    assert(MIN_DATA_POINTS_FOR_TESTS > 0);
-    assert(MAX_DATA_POINTS_FOR_EXACT > MIN_DATA_POINTS_FOR_TESTS);
+    EXPECT_TRUE(DEFAULT_BOOTSTRAP_SAMPLES > MIN_BOOTSTRAP_SAMPLES);
+    EXPECT_TRUE(MAX_BOOTSTRAP_SAMPLES > DEFAULT_BOOTSTRAP_SAMPLES);
+    EXPECT_TRUE(DEFAULT_CV_FOLDS > 0);
+    EXPECT_TRUE(MIN_DATA_POINTS_FOR_TESTS > 0);
+    EXPECT_TRUE(MAX_DATA_POINTS_FOR_EXACT > MIN_DATA_POINTS_FOR_TESTS);
 
     // Test thread parameters
-    assert(THREAD_SAFETY_TEST_THREADS > 0);
-    assert(OPERATIONS_PER_THREAD > 0);
-    assert(PARALLEL_BATCH_COUNT > 0);
-    assert(CACHE_INVALIDATION_COUNT > 0);
+    EXPECT_TRUE(THREAD_SAFETY_TEST_THREADS > 0);
+    EXPECT_TRUE(OPERATIONS_PER_THREAD > 0);
+    EXPECT_TRUE(PARALLEL_BATCH_COUNT > 0);
+    EXPECT_TRUE(CACHE_INVALIDATION_COUNT > 0);
 
     std::cout << "   ✓ Test infrastructure constants tests passed" << std::endl;
 }
@@ -591,263 +591,28 @@ void test_compile_time_validation() {
 // COMMAND-LINE ARGUMENT PARSING
 //==============================================================================
 
-struct TestOptions {
-    bool test_all = false;
-    bool test_essential = false;
-    bool test_mathematical = false;
-    bool test_precision = false;
-    bool test_statistical = false;
-    bool test_benchmark = false;
-    bool test_threshold = false;
-    bool test_robust = false;
-    bool test_goodness = false;
-    bool test_probability = false;
-    bool test_platform = false;
-    bool test_simd = false;
-    bool test_tests = false;
-    bool test_methods = false;
-    bool show_help = false;
-};
+;
 
-void print_help() {
-    std::cout << "Usage: test_constants [options]\n\n";
-    std::cout << "Test all libstats constants headers with selective options:\n\n";
-    std::cout << "Options:\n";
-    std::cout << "  --all/-a           Test all constants (default)\n";
-    std::cout << "  --essential/-e     Test essential constants only\n";
-    std::cout << "  --mathematical/-m  Test mathematical constants\n";
-    std::cout << "  --precision/-p     Test precision constants\n";
-    std::cout << "  --statistical/-s   Test statistical constants\n";
-    std::cout << "  --benchmark/-b     Test benchmark constants\n";
-    std::cout << "  --threshold/-t     Test threshold constants\n";
-    std::cout << "  --robust/-r         Test robust estimation constants\n";
-    std::cout << "  --goodness/-g      Test goodness-of-fit constants\n";
-    std::cout << "  --probability/-P   Test probability constants\n";
-    std::cout << "  --platform/-L      Test platform constants\n";
-    std::cout << "  --simd/-S          Test SIMD constants\n";
-    std::cout << "  --tests/-T         Test test infrastructure constants\n";
-    std::cout << "  --methods/-M       Test statistical methods constants\n";
-    std::cout << "  --help/-h          Show this help\n\n";
-    std::cout << "Examples:\n";
-    std::cout << "  test_constants                    # Test all constants\n";
-    std::cout << "  test_constants --essential        # Test only essential constants\n";
-    std::cout << "  test_constants -m -p -s          # Test math, precision, statistical\n";
-    std::cout << "  test_constants --benchmark --simd # Test benchmark and SIMD constants\n";
-}
 
-TestOptions parse_arguments(int argc, char* argv[]) {
-    TestOptions options;
-    bool any_specific_test = false;
 
-    for (int i = 1; i < argc; ++i) {
-        std::string arg(argv[i]);
 
-        if (arg == "--all" || arg == "-a") {
-            options.test_all = true;
-        } else if (arg == "--essential" || arg == "-e") {
-            options.test_essential = true;
-            any_specific_test = true;
-        } else if (arg == "--mathematical" || arg == "-m") {
-            options.test_mathematical = true;
-            any_specific_test = true;
-        } else if (arg == "--precision" || arg == "-p") {
-            options.test_precision = true;
-            any_specific_test = true;
-        } else if (arg == "--statistical" || arg == "-s") {
-            options.test_statistical = true;
-            any_specific_test = true;
-        } else if (arg == "--benchmark" || arg == "-b") {
-            options.test_benchmark = true;
-            any_specific_test = true;
-        } else if (arg == "--threshold" || arg == "-t") {
-            options.test_threshold = true;
-            any_specific_test = true;
-        } else if (arg == "--robust" || arg == "-r") {
-            options.test_robust = true;
-            any_specific_test = true;
-        } else if (arg == "--goodness" || arg == "-g") {
-            options.test_goodness = true;
-            any_specific_test = true;
-        } else if (arg == "--probability" || arg == "-P") {
-            options.test_probability = true;
-            any_specific_test = true;
-        } else if (arg == "--platform" || arg == "-L") {
-            options.test_platform = true;
-            any_specific_test = true;
-        } else if (arg == "--simd" || arg == "-S") {
-            options.test_simd = true;
-            any_specific_test = true;
-        } else if (arg == "--tests" || arg == "-T") {
-            options.test_tests = true;
-            any_specific_test = true;
-        } else if (arg == "--methods" || arg == "-M") {
-            options.test_methods = true;
-            any_specific_test = true;
-        } else if (arg == "--help" || arg == "-h") {
-            options.show_help = true;
-            return options;
-        } else {
-            std::cerr << "Unknown option: " << arg << "\n";
-            std::cerr << "Use --help/-h for usage information.\n";
-            options.show_help = true;
-            return options;
-        }
-    }
-
-    // If no specific tests requested, default to all
-    if (!any_specific_test && !options.test_all) {
-        options.test_all = true;
-    }
-
-    return options;
-}
 
 //==============================================================================
 // MAIN FUNCTION WITH COMMAND-LINE SUPPORT
 //==============================================================================
 
-int main(int argc, char* argv[]) {
-    TestOptions options = parse_arguments(argc, argv);
 
-    if (options.show_help) {
-        print_help();
-        return 0;
-    }
-
-    std::cout << "Testing libstats constants headers...\n\n";
-
-    int tests_run = 0;
-    int tests_passed = 0;
-
-    // Run selected tests
-    if (options.test_all || options.test_essential) {
-        std::cout << "[Essential Constants]\n";
-        test_math_constants();
-        test_precision_constants();
-        test_statistical_critical_values();
-        tests_run += 3;
-        tests_passed += 3;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_mathematical) {
-        std::cout << "[Mathematical Constants]\n";
-        test_math_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_precision) {
-        std::cout << "[Precision Constants]\n";
-        test_precision_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_statistical) {
-        std::cout << "[Statistical Constants]\n";
-        test_statistical_critical_values();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_benchmark) {
-        std::cout << "[Benchmark Constants]\n";
-        test_benchmark_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_threshold) {
-        std::cout << "[Threshold Constants]\n";
-        test_threshold_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_robust) {
-        std::cout << "[Robust Estimation Constants]\n";
-        test_robust_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_goodness) {
-        std::cout << "[Goodness-of-Fit Constants]\n";
-        test_goodness_of_fit_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_probability) {
-        std::cout << "[Probability Constants]\n";
-        test_probability_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_platform) {
-        std::cout << "[Platform Constants]\n";
-        test_platform_optimizations();
-        test_parallel_constants();
-        tests_run += 2;
-        tests_passed += 2;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_simd) {
-        std::cout << "[SIMD Constants]\n";
-        test_simd_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_tests) {
-        std::cout << "[Test Infrastructure Constants]\n";
-        test_test_infrastructure_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    if (options.test_all || options.test_methods) {
-        std::cout << "[Statistical Methods Constants]\n";
-        test_statistical_methods_constants();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    // Always run compile-time validation
-    if (options.test_all || tests_run > 0) {
-        std::cout << "[Compile-time Validation]\n";
-        test_compile_time_validation();
-        tests_run++;
-        tests_passed++;
-        std::cout << std::endl;
-    }
-
-    // Print summary
-    std::cout << "=== Test Summary ===\n";
-    std::cout << "Tests run: " << tests_run << "\n";
-    std::cout << "Tests passed: " << tests_passed << "\n";
-    if (tests_passed == tests_run && tests_run > 0) {
-        std::cout << "✓ All tests passed!\n";
-        return 0;
-    } else if (tests_run == 0) {
-        std::cout << "No tests were run. Use --help for usage information.\n";
-        return 1;
-    } else {
-        std::cout << "✗ Some tests failed!\n";
-        return 1;
-    }
-}
+TEST(Constants, MathConstants)              { test_math_constants(); }
+TEST(Constants, ProbabilityConstants)       { test_probability_constants(); }
+TEST(Constants, PrecisionConstants)         { test_precision_constants(); }
+TEST(Constants, SimdConstants)              { test_simd_constants(); }
+TEST(Constants, PlatformOptimizations)      { test_platform_optimizations(); }
+TEST(Constants, ParallelConstants)          { test_parallel_constants(); }
+TEST(Constants, StatisticalCriticalValues)  { test_statistical_critical_values(); }
+TEST(Constants, ThresholdConstants)         { test_threshold_constants(); }
+TEST(Constants, BenchmarkConstants)         { test_benchmark_constants(); }
+TEST(Constants, RobustConstants)            { test_robust_constants(); }
+TEST(Constants, GoodnessOfFitConstants)     { test_goodness_of_fit_constants(); }
+TEST(Constants, StatisticalMethods)         { test_statistical_methods_constants(); }
+TEST(Constants, TestInfrastructure)         { test_test_infrastructure_constants(); }
+TEST(Constants, CompileTimeValidation)      { test_compile_time_validation(); }

--- a/tests/test_error_handling_comprehensive.cpp
+++ b/tests/test_error_handling_comprehensive.cpp
@@ -7,8 +7,9 @@
 
 // Standard library includes
 #include <algorithm>
+#include <gtest/gtest.h>
 #include <atomic>
-#include <cassert>
+#include <gtest/gtest.h>
 #include <chrono>
 #include <cmath>
 #include <iostream>
@@ -24,44 +25,14 @@ using namespace stats;
 using namespace std;
 
 // Test configuration
-struct TestConfig {
-    bool test_all = true;
-    bool test_factory = false;
-    bool test_dual_api = false;
-    bool test_validation = false;
-    bool test_distributions = false;
-    bool test_stress = false;
-    bool test_benchmarks = false;
-    bool verbose = false;
-    vector<string> specific_distributions;
-    size_t stress_iterations = 1000;
-    size_t thread_count = 4;
-};
+;
 
 // Test statistics
 struct TestStats {
-    int total_tests = 0;
-    int passed = 0;
-    int failed = 0;
-
-    void record(bool success, const string& test_name) {
-        total_tests++;
-        if (success) {
-            passed++;
-            cout << "  ✓ " << test_name << endl;
-        } else {
-            failed++;
-            cout << "  ✗ " << test_name << " FAILED" << endl;
-        }
+    void record(bool success, const std::string& test_name) {
+        EXPECT_TRUE(success) << test_name;
     }
-
-    void print_summary(const string& category) {
-        cout << "\n" << category << " Results: " << passed << "/" << total_tests << " passed";
-        if (failed > 0) {
-            cout << " (" << failed << " failed)";
-        }
-        cout << endl;
-    }
+    void print_summary([[maybe_unused]] const std::string& category) {}
 };
 
 // Helper function for comparing doubles
@@ -74,7 +45,7 @@ bool approx_equal(T a, T b, T epsilon = 1e-10) {
 // SAFE FACTORY METHOD TESTS
 //==============================================================================
 
-void test_factory_methods(const TestConfig& config) {
+void test_factory_methods() {
     cout << "\n=== Testing Safe Factory Methods ===" << endl;
     TestStats stats;
 
@@ -107,7 +78,7 @@ void test_factory_methods(const TestConfig& config) {
         auto badResult4 = GaussianDistribution::create(0.0, numeric_limits<double>::quiet_NaN());
         stats.record(badResult4.isError(), "Gaussian rejects NaN standard deviation");
 
-        if (config.verbose && badResult1.isError()) {
+        if (false && badResult1.isError()) {
             cout << "    Error message: " << badResult1.message << endl;
         }
     }
@@ -179,7 +150,7 @@ void test_factory_methods(const TestConfig& config) {
 // DUAL API TESTS
 //==============================================================================
 
-void test_dual_api([[maybe_unused]] const TestConfig& config) {
+void test_dual_api() {
     cout << "\n=== Testing Dual API (Exception/Result) ===" << endl;
     TestStats stats;
 
@@ -335,7 +306,7 @@ void test_dual_api([[maybe_unused]] const TestConfig& config) {
 // PARAMETER VALIDATION TESTS
 //==============================================================================
 
-void test_parameter_validation(const TestConfig& config) {
+void test_parameter_validation() {
     cout << "\n=== Testing Parameter Validation ===" << endl;
     TestStats stats;
 
@@ -390,7 +361,7 @@ void test_parameter_validation(const TestConfig& config) {
     }
 
     // Test error message quality
-    if (config.verbose) {
+    if (false) {
         cout << "\n  Sample error messages:" << endl;
 
         auto badGauss = GaussianDistribution::create(0.0, -1.0);
@@ -416,8 +387,7 @@ void test_parameter_validation(const TestConfig& config) {
 // DISTRIBUTION-SPECIFIC ERROR HANDLING TESTS
 //==============================================================================
 
-void test_specific_distribution(const string& dist_name, TestStats& stats,
-                                [[maybe_unused]] const TestConfig& config) {
+void test_specific_distribution(const string& dist_name, TestStats& stats) {
     if (dist_name == "gaussian" || dist_name == "all") {
         auto result = GaussianDistribution::create(0.0, 1.0);
         if (result.isOk()) {
@@ -514,18 +484,18 @@ void test_specific_distribution(const string& dist_name, TestStats& stats,
     }
 }
 
-void test_distributions(const TestConfig& config) {
+void test_distributions() {
     cout << "\n=== Testing Distribution-Specific Error Handling ===" << endl;
     TestStats stats;
 
-    if (config.specific_distributions.empty()) {
+    if (std::vector<std::string>().empty()) {
         // Test all distributions
-        test_specific_distribution("all", stats, config);
+        test_specific_distribution("all", stats);
     } else {
         // Test specific distributions
-        for (const auto& dist : config.specific_distributions) {
+        for (const auto& dist : std::vector<std::string>()) {
             cout << "\n  Testing " << dist << ":" << endl;
-            test_specific_distribution(dist, stats, config);
+            test_specific_distribution(dist, stats);
         }
     }
 
@@ -536,9 +506,9 @@ void test_distributions(const TestConfig& config) {
 // STRESS TESTS
 //==============================================================================
 
-void test_stress(const TestConfig& config) {
+void test_stress() {
     cout << "\n=== Stress Testing Error Handling ===" << endl;
-    cout << "Running " << config.stress_iterations << " iterations with " << config.thread_count
+    cout << "Running " << 1000 << " iterations with " << 4
          << " threads" << endl;
 
     atomic<int> successes(0);
@@ -551,13 +521,13 @@ void test_stress(const TestConfig& config) {
             auto dist = make_shared<GaussianDistribution>(std::move(result.value));
 
             vector<thread> threads;
-            for (size_t t = 0; t < config.thread_count; ++t) {
+            for (size_t t = 0; t < 4; ++t) {
                 threads.emplace_back([&, t]() {
                     mt19937 rng(static_cast<uint32_t>(42 + t));  // C4267: explicit size_t→uint32_t
                     uniform_real_distribution<> mean_dist(-100, 100);
                     uniform_real_distribution<> std_dist(0.1, 10);
 
-                    for (size_t i = 0; i < config.stress_iterations / config.thread_count; ++i) {
+                    for (size_t i = 0; i < 1000 / 4; ++i) {
                         // Randomly choose between valid and invalid updates
                         if (rng() % 2 == 0) {
                             auto r = dist->trySetParameters(mean_dist(rng), std_dist(rng));
@@ -593,7 +563,7 @@ void test_stress(const TestConfig& config) {
         int factory_successes = 0;
         int factory_failures = 0;
 
-        for (size_t i = 0; i < config.stress_iterations; ++i) {
+        for (size_t i = 0; i < 1000; ++i) {
             double p1 = param_dist(rng);
             double p2 = param_dist(rng);
 
@@ -626,7 +596,7 @@ void test_stress(const TestConfig& config) {
 // PERFORMANCE BENCHMARKS
 //==============================================================================
 
-void test_benchmarks([[maybe_unused]] const TestConfig& config) {
+void test_benchmarks() {
     cout << "\n=== Performance Benchmarks ===" << endl;
 
     const size_t iterations = 100000;
@@ -686,131 +656,14 @@ void test_benchmarks([[maybe_unused]] const TestConfig& config) {
 // MAIN FUNCTION AND ARGUMENT PARSING
 //==============================================================================
 
-void print_usage(const char* program_name) {
-    cout << "Usage: " << program_name << " [options]\n\n";
-    cout << "Comprehensive Error Handling Test Suite\n";
-    cout << "Tests safe factory methods and dual API across all distributions\n\n";
-    cout << "Options:\n";
-    cout << "  --all/-a              Test all components (default)\n";
-    cout << "  --factory/-f          Test safe factory methods\n";
-    cout << "  --dual-api/-d         Test dual API (exception/Result)\n";
-    cout << "  --validation/-v       Test parameter validation\n";
-    cout << "  --distributions/-D    Test specific distribution(s)\n";
-    cout << "  --stress/-s           Run concurrent stress tests\n";
-    cout << "  --benchmarks/-b       Run performance benchmarks\n";
-    cout << "  --verbose/-V          Enable verbose output\n";
-    cout << "  --dist NAME           Test specific distribution (can be repeated)\n";
-    cout << "  --iterations N        Set stress test iterations (default: 1000)\n";
-    cout << "  --threads N           Set thread count for stress tests (default: 4)\n";
-    cout << "  --help/-h             Show this help\n\n";
-    cout << "Available distributions:\n";
-    cout << "  gaussian, uniform, exponential, poisson, discrete, gamma\n\n";
-    cout << "Examples:\n";
-    cout << "  " << program_name << "                    # Test everything\n";
-    cout << "  " << program_name << " --factory --dual-api # Test APIs\n";
-    cout << "  " << program_name << " --dist gaussian --dist uniform\n";
-    cout << "  " << program_name << " --stress --iterations 10000 --threads 8\n";
-}
 
-TestConfig parse_args(int argc, char* argv[]) {
-    TestConfig config;
 
-    if (argc == 1) {
-        return config;  // Default: test all
-    }
 
-    config.test_all = false;  // If args provided, don't test all by default
 
-    for (int i = 1; i < argc; ++i) {
-        string arg = argv[i];
 
-        if (arg == "--help" || arg == "-h") {
-            print_usage(argv[0]);
-            exit(0);
-        } else if (arg == "--all" || arg == "-a") {
-            config.test_all = true;
-        } else if (arg == "--factory" || arg == "-f") {
-            config.test_factory = true;
-        } else if (arg == "--dual-api" || arg == "-d") {
-            config.test_dual_api = true;
-        } else if (arg == "--validation" || arg == "-v") {
-            config.test_validation = true;
-        } else if (arg == "--distributions" || arg == "-D") {
-            config.test_distributions = true;
-        } else if (arg == "--stress" || arg == "-s") {
-            config.test_stress = true;
-        } else if (arg == "--benchmarks" || arg == "-b") {
-            config.test_benchmarks = true;
-        } else if (arg == "--verbose" || arg == "-V") {
-            config.verbose = true;
-        } else if (arg == "--dist" && i + 1 < argc) {
-            config.specific_distributions.push_back(argv[++i]);
-            config.test_distributions = true;
-        } else if (arg == "--iterations" && i + 1 < argc) {
-            config.stress_iterations = stoul(argv[++i]);
-        } else if (arg == "--threads" && i + 1 < argc) {
-            config.thread_count = stoul(argv[++i]);
-        } else {
-            cerr << "Unknown option: " << arg << endl;
-            print_usage(argv[0]);
-            exit(1);
-        }
-    }
-
-    // If no specific tests selected, test all
-    if (!config.test_factory && !config.test_dual_api && !config.test_validation &&
-        !config.test_distributions && !config.test_stress && !config.test_benchmarks) {
-        config.test_all = true;
-    }
-
-    return config;
-}
-
-int main(int argc, char* argv[]) {
-    TestConfig config = parse_args(argc, argv);
-
-    cout << "=== Comprehensive Error Handling Test Suite ===" << endl;
-    cout << "Testing safe factory methods and dual API\n" << endl;
-
-    int total_sections = 0;
-
-    try {
-        if (config.test_all || config.test_factory) {
-            test_factory_methods(config);
-            total_sections++;
-        }
-
-        if (config.test_all || config.test_dual_api) {
-            test_dual_api(config);
-            total_sections++;
-        }
-
-        if (config.test_all || config.test_validation) {
-            test_parameter_validation(config);
-            total_sections++;
-        }
-
-        if (config.test_all || config.test_distributions) {
-            test_distributions(config);
-            total_sections++;
-        }
-
-        if (config.test_stress) {  // Only run if explicitly requested
-            test_stress(config);
-            total_sections++;
-        }
-
-        if (config.test_all || config.test_benchmarks) {
-            test_benchmarks(config);
-            total_sections++;
-        }
-
-        cout << "\n=== Test Suite Complete ===" << endl;
-        cout << "Tested " << total_sections << " component(s)" << endl;
-
-        return 0;
-    } catch (const exception& e) {
-        cerr << "Test failed with exception: " << e.what() << endl;
-        return 1;
-    }
-}
+TEST(ErrorHandling, FactoryMethods)          { test_factory_methods(); }
+TEST(ErrorHandling, DualApi)                 { test_dual_api(); }
+TEST(ErrorHandling, ParameterValidation)     { test_parameter_validation(); }
+TEST(ErrorHandling, DistributionSpecific)    { test_distributions(); }
+TEST(ErrorHandling, StressTests)             { test_stress(); }
+TEST(ErrorHandling, Benchmarks)              { test_benchmarks(); }

--- a/tests/test_numerical_safety.cpp
+++ b/tests/test_numerical_safety.cpp
@@ -8,7 +8,8 @@
 
 // Standard library includes
 #include <algorithm>
-#include <cassert>
+#include <gtest/gtest.h>
+#include <gtest/gtest.h>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -26,44 +27,14 @@ using namespace stats::detail;
 using namespace std;
 
 // Test configuration
-struct TestConfig {
-    bool test_all = true;
-    bool test_scalar = false;
-    bool test_vector = false;
-    bool test_log_space = false;
-    bool test_edge_cases = false;
-    bool test_benchmarks = false;
-    bool test_precision = false;
-    bool test_stress = false;
-    bool verbose = false;
-    size_t benchmark_size = 10000;
-    size_t stress_iterations = 1000;
-};
+;
 
 // Test statistics
 struct TestStats {
-    int total_tests = 0;
-    int passed = 0;
-    int failed = 0;
-
-    void record(bool success, const string& test_name) {
-        total_tests++;
-        if (success) {
-            passed++;
-            cout << "  ✓ " << test_name << endl;
-        } else {
-            failed++;
-            cout << "  ✗ " << test_name << " FAILED" << endl;
-        }
+    void record(bool success, const std::string& test_name) {
+        EXPECT_TRUE(success) << test_name;
     }
-
-    void print_summary(const string& category) {
-        cout << "\n" << category << " Results: " << passed << "/" << total_tests << " passed";
-        if (failed > 0) {
-            cout << " (" << failed << " failed)";
-        }
-        cout << endl;
-    }
+    void print_summary([[maybe_unused]] const std::string& category) {}
 };
 
 // Helper functions
@@ -91,7 +62,7 @@ double reference_log_sum_exp(double log_a, double log_b) {
 // SCALAR SAFETY FUNCTION TESTS
 //==============================================================================
 
-void test_scalar_safety([[maybe_unused]] const TestConfig& config) {
+void test_scalar_safety() {
     cout << "\n=== Testing Scalar Safety Functions ===" << endl;
     TestStats stats;
 
@@ -173,7 +144,7 @@ void test_scalar_safety([[maybe_unused]] const TestConfig& config) {
 // VECTORIZED SAFETY FUNCTION TESTS
 //==============================================================================
 
-void test_vector_safety(const TestConfig& config) {
+void test_vector_safety() {
     cout << "\n=== Testing Vectorized Safety Functions ===" << endl;
     TestStats stats;
 
@@ -232,7 +203,7 @@ void test_vector_safety(const TestConfig& config) {
     }
 
     // Test large array consistency
-    if (config.verbose) {
+    if (false) {
         cout << "  Testing large array consistency..." << endl;
     }
     {
@@ -276,7 +247,7 @@ void test_vector_safety(const TestConfig& config) {
 // LOG-SPACE OPERATIONS TESTS
 //==============================================================================
 
-void test_log_space_operations([[maybe_unused]] const TestConfig& config) {
+void test_log_space_operations() {
     cout << "\n=== Testing Log-Space Operations ===" << endl;
     TestStats stats;
 
@@ -377,7 +348,7 @@ void test_log_space_operations([[maybe_unused]] const TestConfig& config) {
 // EDGE CASES TESTS
 //==============================================================================
 
-void test_edge_cases([[maybe_unused]] const TestConfig& config) {
+void test_edge_cases() {
     cout << "\n=== Testing Edge Cases ===" << endl;
     TestStats stats;
 
@@ -445,11 +416,11 @@ void test_edge_cases([[maybe_unused]] const TestConfig& config) {
 // PERFORMANCE BENCHMARKS
 //==============================================================================
 
-void test_benchmarks(const TestConfig& config) {
+void test_benchmarks() {
     cout << "\n=== Performance Benchmarks ===" << endl;
-    cout << "Benchmark size: " << config.benchmark_size << " elements\n" << endl;
+    cout << "Benchmark size: " << 10000 << " elements\n" << endl;
 
-    const size_t size = config.benchmark_size;
+    const size_t size = 10000;
     vector<double> input(size);
     vector<double> output(size);
 
@@ -543,7 +514,7 @@ void test_benchmarks(const TestConfig& config) {
 // PRECISION TESTS
 //==============================================================================
 
-void test_precision(const TestConfig& config) {
+void test_precision() {
     cout << "\n=== Precision and Accuracy Tests ===" << endl;
 
     mt19937 rng(42);
@@ -586,7 +557,7 @@ void test_precision(const TestConfig& config) {
             double exp_result = safe_exp(log_result);
             if (!approx_equal(exp_result, val, 1e-10)) {
                 all_precise = false;
-                if (config.verbose) {
+                if (false) {
                     cout << "  Precision loss: exp(safe_log(" << val << ")) = " << exp_result
                          << endl;
                 }
@@ -611,9 +582,9 @@ void test_precision(const TestConfig& config) {
 // STRESS TESTS
 //==============================================================================
 
-void test_stress(const TestConfig& config) {
+void test_stress() {
     cout << "\n=== Stress Tests ===" << endl;
-    cout << "Running " << config.stress_iterations << " iterations..." << endl;
+    cout << "Running " << 1000 << " iterations..." << endl;
 
     mt19937 rng(42);
     uniform_real_distribution<> dist(-100, 100);
@@ -624,7 +595,7 @@ void test_stress(const TestConfig& config) {
         int crashes = 0;
         int invalid = 0;
 
-        for (size_t i = 0; i < config.stress_iterations; ++i) {
+        for (size_t i = 0; i < 1000; ++i) {
             vector<double> extreme_values = {LogSpaceOps::LOG_ZERO,
                                              numeric_limits<double>::max(),
                                              -numeric_limits<double>::max(),
@@ -660,8 +631,8 @@ void test_stress(const TestConfig& config) {
             }
         }
 
-        cout << "  Completed: " << (config.stress_iterations - static_cast<size_t>(crashes)) << "/"
-             << config.stress_iterations << endl;
+        cout << "  Completed: " << (1000 - static_cast<size_t>(crashes)) << "/"
+             << 1000 << endl;
         cout << "  Invalid results: " << invalid << endl;
         cout << "  Crashes: " << crashes << endl;
     }
@@ -697,7 +668,7 @@ void test_stress(const TestConfig& config) {
     }
 
     // Thread safety stress test (if applicable)
-    if (config.verbose) {
+    if (false) {
         cout << "\nNote: Thread safety testing would require multi-threading support" << endl;
     }
 }
@@ -706,132 +677,15 @@ void test_stress(const TestConfig& config) {
 // MAIN FUNCTION AND ARGUMENT PARSING
 //==============================================================================
 
-void print_usage(const char* program_name) {
-    cout << "Usage: " << program_name << " [options]\n\n";
-    cout << "Comprehensive Numerical Safety Test Suite\n";
-    cout << "Tests core/safety.h and core/log_space_ops.h functionality\n\n";
-    cout << "Options:\n";
-    cout << "  --all/-a              Test all components (default)\n";
-    cout << "  --scalar/-s           Test scalar safety functions\n";
-    cout << "  --vector/-v           Test vectorized safety functions\n";
-    cout << "  --log-space/-l        Test log-space operations\n";
-    cout << "  --edge-cases/-e       Test edge cases\n";
-    cout << "  --benchmarks/-b       Run performance benchmarks\n";
-    cout << "  --precision/-p        Test numerical precision\n";
-    cout << "  --stress/-S           Run stress tests\n";
-    cout << "  --verbose/-V          Enable verbose output\n";
-    cout << "  --size N              Set benchmark array size (default: 10000)\n";
-    cout << "  --iterations N        Set stress test iterations (default: 1000)\n";
-    cout << "  --help/-h             Show this help\n\n";
-    cout << "Examples:\n";
-    cout << "  " << program_name << "                    # Test everything\n";
-    cout << "  " << program_name << " --scalar --vector   # Test safety functions\n";
-    cout << "  " << program_name << " --log-space --benchmarks\n";
-    cout << "  " << program_name << " --stress --iterations 10000\n";
-}
 
-TestConfig parse_args(int argc, char* argv[]) {
-    TestConfig config;
 
-    if (argc == 1) {
-        return config;  // Default: test all
-    }
 
-    config.test_all = false;  // If args provided, don't test all by default
 
-    for (int i = 1; i < argc; ++i) {
-        string arg = argv[i];
 
-        if (arg == "--help" || arg == "-h") {
-            print_usage(argv[0]);
-            exit(0);
-        } else if (arg == "--all" || arg == "-a") {
-            config.test_all = true;
-        } else if (arg == "--scalar" || arg == "-s") {
-            config.test_scalar = true;
-        } else if (arg == "--vector" || arg == "-v") {
-            config.test_vector = true;
-        } else if (arg == "--log-space" || arg == "-l") {
-            config.test_log_space = true;
-        } else if (arg == "--edge-cases" || arg == "-e") {
-            config.test_edge_cases = true;
-        } else if (arg == "--benchmarks" || arg == "-b") {
-            config.test_benchmarks = true;
-        } else if (arg == "--precision" || arg == "-p") {
-            config.test_precision = true;
-        } else if (arg == "--stress" || arg == "-S") {
-            config.test_stress = true;
-        } else if (arg == "--verbose" || arg == "-V") {
-            config.verbose = true;
-        } else if (arg == "--size" && i + 1 < argc) {
-            config.benchmark_size = stoul(argv[++i]);
-        } else if (arg == "--iterations" && i + 1 < argc) {
-            config.stress_iterations = stoul(argv[++i]);
-        } else {
-            cerr << "Unknown option: " << arg << endl;
-            print_usage(argv[0]);
-            exit(1);
-        }
-    }
-
-    // If no specific tests selected, test all
-    if (!config.test_scalar && !config.test_vector && !config.test_log_space &&
-        !config.test_edge_cases && !config.test_benchmarks && !config.test_precision &&
-        !config.test_stress) {
-        config.test_all = true;
-    }
-
-    return config;
-}
-
-int main(int argc, char* argv[]) {
-    TestConfig config = parse_args(argc, argv);
-
-    cout << "=== Numerical Safety Test Suite ===" << endl;
-    cout << "Testing core/safety.h and core/log_space_ops.h\n" << endl;
-
-    // Initialize log-space operations
-    LogSpaceOps::initialize();
-
-    int total_sections = 0;
-
-    if (config.test_all || config.test_scalar) {
-        test_scalar_safety(config);
-        total_sections++;
-    }
-
-    if (config.test_all || config.test_vector) {
-        test_vector_safety(config);
-        total_sections++;
-    }
-
-    if (config.test_all || config.test_log_space) {
-        test_log_space_operations(config);
-        total_sections++;
-    }
-
-    if (config.test_all || config.test_edge_cases) {
-        test_edge_cases(config);
-        total_sections++;
-    }
-
-    if (config.test_all || config.test_precision) {
-        test_precision(config);
-        total_sections++;
-    }
-
-    if (config.test_all || config.test_benchmarks) {
-        test_benchmarks(config);
-        total_sections++;
-    }
-
-    if (config.test_stress) {  // Only run if explicitly requested
-        test_stress(config);
-        total_sections++;
-    }
-
-    cout << "\n=== Test Suite Complete ===" << endl;
-    cout << "Tested " << total_sections << " component(s)" << endl;
-
-    return 0;
-}
+TEST(NumericalSafety, ScalarSafety)       { test_scalar_safety(); }
+TEST(NumericalSafety, VectorSafety)       { test_vector_safety(); }
+TEST(NumericalSafety, LogSpaceOperations) { test_log_space_operations(); }
+TEST(NumericalSafety, EdgeCases)          { test_edge_cases(); }
+TEST(NumericalSafety, Precision)          { test_precision(); }
+TEST(NumericalSafety, Benchmarks)         { test_benchmarks(); }
+TEST(NumericalSafety, StressTests)        { test_stress(); }

--- a/tests/test_parallel_execution_comprehensive.cpp
+++ b/tests/test_parallel_execution_comprehensive.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cassert>
 #include <chrono>
 #include <iostream>
 #include <numeric>
@@ -10,63 +9,49 @@
 #define LIBSTATS_FULL_INTERFACE
 #include "libstats/libstats.h"
 
-int main() {
-    std::cout << "=== Comprehensive Parallel Execution Tests ===" << std::endl;
+#include <gtest/gtest.h>
 
-    // Test 1: GCD-specific algorithm coverage
-    std::cout << "Test 1: GCD-specific algorithm implementations" << std::endl;
-
-    // Test safe_count with GCD
+TEST(ParallelExecutionComprehensive, GCDAlgorithms) {
     std::vector<int> count_data = {1, 2, 3, 2, 4, 2, 5, 2};
-    [[maybe_unused]] auto count_result =
-        stats::arch::safe_count(count_data.begin(), count_data.end(), 2);
-    assert(count_result == 4);
+
+    auto count_result = stats::arch::safe_count(count_data.begin(), count_data.end(), 2);
+    EXPECT_EQ(count_result, 4);
     std::cout << "  - safe_count (GCD): PASSED" << std::endl;
 
-    // Test safe_count_if with GCD
-    [[maybe_unused]] auto count_if_result = stats::arch::safe_count_if(
+    auto count_if_result = stats::arch::safe_count_if(
         count_data.begin(), count_data.end(), [](int x) { return x > 2; });
-    assert(count_if_result == 3);
+    EXPECT_EQ(count_if_result, 3);
     std::cout << "  - safe_count_if (GCD): PASSED" << std::endl;
 
-    // Test safe_reduce (sum operation is the default)
     std::vector<double> reduce_data(1000, 2.0);
-    [[maybe_unused]] auto sum_result =
-        stats::arch::safe_reduce(reduce_data.begin(), reduce_data.end(), 0.0);
-    assert(std::abs(sum_result - 2000.0) < 1e-10);
-    std::cout << "  - safe_reduce with custom op (GCD): PASSED" << std::endl;
+    auto sum_result = stats::arch::safe_reduce(reduce_data.begin(), reduce_data.end(), 0.0);
+    EXPECT_NEAR(sum_result, 2000.0, 1e-10);
+    std::cout << "  - safe_reduce (GCD): PASSED" << std::endl;
+}
 
-    // Test 2: Edge cases and boundary conditions
-    std::cout << "Test 2: Edge cases and boundary conditions" << std::endl;
-
-    // Single element
+TEST(ParallelExecutionComprehensive, EdgeCasesAndBoundaryConditions) {
     std::vector<int> single = {42};
     stats::arch::safe_fill(single.begin(), single.end(), 100);
-    assert(single[0] == 100);
+    EXPECT_EQ(single[0], 100);
     std::cout << "  - Single element fill: PASSED" << std::endl;
 
-    // Large dataset to ensure parallel execution
     std::vector<double> large_data(100000);
     std::iota(large_data.begin(), large_data.end(), 1.0);
 
-    // Test parallel transform on large dataset
     std::vector<double> large_output(100000);
     stats::arch::safe_transform(large_data.begin(), large_data.end(), large_output.begin(),
                                 [](double x) { return x * x; });
-    assert(large_output[0] == 1.0 && large_output[999] == 1000000.0);
+    EXPECT_EQ(large_output[0], 1.0);
+    EXPECT_EQ(large_output[999], 1000000.0);
     std::cout << "  - Large dataset transform: PASSED" << std::endl;
 
-    // Test parallel reduce on large dataset
-    [[maybe_unused]] auto large_sum =
-        stats::arch::safe_reduce(large_data.begin(), large_data.end(), 0.0);
-    [[maybe_unused]] double expected_sum = (100000.0 * 100001.0) / 2.0;  // Sum of 1..100000
-    assert(std::abs(large_sum - expected_sum) < 1.0);  // Allow small floating point error
+    auto large_sum = stats::arch::safe_reduce(large_data.begin(), large_data.end(), 0.0);
+    double expected_sum = (100000.0 * 100001.0) / 2.0;
+    EXPECT_NEAR(large_sum, expected_sum, 1.0);
     std::cout << "  - Large dataset reduce: PASSED" << std::endl;
+}
 
-    // Test 3: Algorithm correctness under parallel execution
-    std::cout << "Test 3: Algorithm correctness verification" << std::endl;
-
-    // Test that parallel and serial give same results
+TEST(ParallelExecutionComprehensive, AlgorithmCorrectnessVerification) {
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_real_distribution<double> dis(0.0, 100.0);
@@ -74,197 +59,95 @@ int main() {
     std::vector<double> test_data(5000);
     std::generate(test_data.begin(), test_data.end(), [&]() { return dis(gen); });
 
-    // Serial results
-    std::vector<double> serial_transform(5000);
-    std::transform(test_data.begin(), test_data.end(), serial_transform.begin(),
+    std::vector<double> serial_result(5000);
+    std::transform(test_data.begin(), test_data.end(), serial_result.begin(),
                    [](double x) { return std::sqrt(x); });
 
-    // Parallel results
-    std::vector<double> parallel_transform(5000);
-    stats::arch::safe_transform(test_data.begin(), test_data.end(), parallel_transform.begin(),
+    std::vector<double> parallel_result(5000);
+    stats::arch::safe_transform(test_data.begin(), test_data.end(), parallel_result.begin(),
                                 [](double x) { return std::sqrt(x); });
 
-    // Compare results
-    [[maybe_unused]] bool transforms_equal =
-        std::equal(serial_transform.begin(), serial_transform.end(), parallel_transform.begin(),
+    bool transforms_equal =
+        std::equal(serial_result.begin(), serial_result.end(), parallel_result.begin(),
                    [](double a, double b) { return std::abs(a - b) < 1e-10; });
-    assert(transforms_equal);
+    EXPECT_TRUE(transforms_equal);
     std::cout << "  - Parallel vs serial transform equivalence: PASSED" << std::endl;
+}
 
-    // Test 4: Performance characteristics (not strict performance test, just sanity check)
-    std::cout << "Test 4: Performance characteristics" << std::endl;
-
+TEST(ParallelExecutionComprehensive, PerformanceCharacteristics) {
     std::vector<double> perf_data(50000);
     std::iota(perf_data.begin(), perf_data.end(), 1.0);
 
-    auto start = std::chrono::high_resolution_clock::now();
-    [[maybe_unused]] auto perf_sum_result =
-        stats::arch::safe_reduce(perf_data.begin(), perf_data.end(), 0.0);
-    auto end = std::chrono::high_resolution_clock::now();
+    auto t0 = std::chrono::high_resolution_clock::now();
+    auto perf_sum = stats::arch::safe_reduce(perf_data.begin(), perf_data.end(), 0.0);
+    auto t1 = std::chrono::high_resolution_clock::now();
+    std::cout << "  - Parallel reduce of 50k elements took: "
+              << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count()
+              << " us" << std::endl;
 
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    std::cout << "  - Parallel reduce of 50k elements took: " << duration.count() << " μs"
-              << std::endl;
-
-    [[maybe_unused]] double expected_perf_sum = (50000.0 * 50001.0) / 2.0;
-    assert(std::abs(perf_sum_result - expected_perf_sum) < 1.0);
+    double expected = (50000.0 * 50001.0) / 2.0;
+    EXPECT_NEAR(perf_sum, expected, 1.0);
     std::cout << "  - Performance test correctness: PASSED" << std::endl;
+}
 
-    // Test 5: Memory safety and exception safety
-    std::cout << "Test 5: Memory and exception safety" << std::endl;
+TEST(ParallelExecutionComprehensive, MemoryAndExceptionSafety) {
+    std::vector<int> empty;
+    auto empty_count = stats::arch::safe_count(empty.begin(), empty.end(), 5);
+    EXPECT_EQ(empty_count, 0);
+    std::cout << "  - Empty container count: PASSED" << std::endl;
 
-    try {
-        // Test with empty containers
-        std::vector<int> empty;
-        [[maybe_unused]] auto empty_count = stats::arch::safe_count(empty.begin(), empty.end(), 5);
-        assert(empty_count == 0);
-        std::cout << "  - Empty container count: PASSED" << std::endl;
+    std::vector<int*> ptr_vec(100, nullptr);
+    auto null_count = stats::arch::safe_count(ptr_vec.begin(), ptr_vec.end(), nullptr);
+    EXPECT_EQ(null_count, 100);
+    std::cout << "  - Null pointer handling: PASSED" << std::endl;
+}
 
-        // Test with null/default values
-        std::vector<int*> ptr_vec(100, nullptr);
-        [[maybe_unused]] auto null_count =
-            stats::arch::safe_count(ptr_vec.begin(), ptr_vec.end(), nullptr);
-        assert(null_count == 100);
-        std::cout << "  - Null pointer handling: PASSED" << std::endl;
+TEST(ParallelExecutionComprehensive, PlatformAdaptiveFeatures) {
+    auto threshold = stats::arch::get_min_elements_for_distribution_parallel();
+    EXPECT_GT(threshold, 0u);
+    EXPECT_LT(threshold, 100000u);
 
-    } catch (const std::exception& e) {
-        std::cout << "  - Exception in safety test: " << e.what() << std::endl;
-    }
+    auto default_grain  = stats::arch::get_default_grain_size();
+    auto optimal_grain  = stats::arch::get_optimal_grain_size();
+    auto simple_grain   = stats::arch::get_simple_operation_grain_size();
+    EXPECT_GT(default_grain, 0u);  EXPECT_LT(default_grain, 50000u);
+    EXPECT_GT(optimal_grain, 0u);  EXPECT_LT(optimal_grain, 50000u);
+    EXPECT_GT(simple_grain,  0u);  EXPECT_LT(simple_grain,  50000u);
 
-    // Test 6: Platform-aware adaptive grain sizing and threading
-    std::cout << "Test 6: Platform-aware adaptive features" << std::endl;
+    auto memory_grain  = stats::arch::get_adaptive_grain_size(0, 10000);
+    auto compute_grain = stats::arch::get_adaptive_grain_size(1, 10000);
+    auto mixed_grain   = stats::arch::get_adaptive_grain_size(2, 10000);
+    EXPECT_GE(memory_grain,  simple_grain);
+    EXPECT_GE(compute_grain, simple_grain);
+    EXPECT_GE(mixed_grain,   simple_grain);
+    EXPECT_GE(compute_grain, memory_grain);
 
-    // Test optimal parallel threshold
-    auto optimal_threshold = stats::arch::get_min_elements_for_distribution_parallel();
-    std::cout << "  - Optimal parallel threshold: " << optimal_threshold << " elements"
-              << std::endl;
-    assert(optimal_threshold > 0 && optimal_threshold < 100000);  // Reasonable range
-
-    // Test different grain size functions to understand their purposes
-    auto default_grain_size = stats::arch::get_default_grain_size();  // Vendor-specific baseline
-    auto optimal_grain_size = stats::arch::get_optimal_grain_size();  // Cache-optimized
-    auto simple_grain_size =
-        stats::arch::get_simple_operation_grain_size();  // Simple operations minimum
-
-    std::cout << "  - Default grain size: " << default_grain_size << " elements" << std::endl;
-    std::cout << "  - Optimal grain size: " << optimal_grain_size << " elements" << std::endl;
-    std::cout << "  - Simple operation grain size: " << simple_grain_size << " elements"
-              << std::endl;
-
-    assert(default_grain_size > 0 && default_grain_size < 50000);  // Reasonable range
-    assert(optimal_grain_size > 0 && optimal_grain_size < 50000);  // Reasonable range
-    assert(simple_grain_size > 0 && simple_grain_size < 50000);    // Reasonable range
-
-    // Test adaptive grain sizes for different operation types
-    auto memory_grain = stats::arch::get_adaptive_grain_size(0, 10000);   // Memory-bound
-    auto compute_grain = stats::arch::get_adaptive_grain_size(1, 10000);  // Computation-bound
-    auto mixed_grain = stats::arch::get_adaptive_grain_size(2, 10000);    // Mixed
-
-    std::cout << "  - Memory-bound grain size: " << memory_grain << " elements" << std::endl;
-    std::cout << "  - Computation-bound grain size: " << compute_grain << " elements" << std::endl;
-    std::cout << "  - Mixed operation grain size: " << mixed_grain << " elements" << std::endl;
-
-    // Verify grain sizes are reasonable (all should be at least the minimum)
-    assert(memory_grain >= simple_grain_size);   // At least minimum
-    assert(compute_grain >= simple_grain_size);  // At least minimum
-    assert(mixed_grain >= simple_grain_size);    // At least minimum
-
-    // Verify basic relationships: computation-bound should be >= memory-bound
-    // (since computation-bound operations benefit from larger grains to amortize thread overhead)
-    assert(compute_grain >= memory_grain);
-
-    // Test optimal thread count
-    auto optimal_threads_small = stats::arch::get_optimal_thread_count(1000);
-    auto optimal_threads_large = stats::arch::get_optimal_thread_count(100000);
-
-    std::cout << "  - Optimal threads (small workload): " << optimal_threads_small << std::endl;
-    std::cout << "  - Optimal threads (large workload): " << optimal_threads_large << std::endl;
-
-    assert(optimal_threads_small >= 1);
-    assert(optimal_threads_large >= 1);
-    // Large workloads may benefit from more threads
-    assert(optimal_threads_large >= optimal_threads_small);
+    auto threads_small = stats::arch::get_optimal_thread_count(1000);
+    auto threads_large = stats::arch::get_optimal_thread_count(100000);
+    EXPECT_GE(threads_small, 1u);
+    EXPECT_GE(threads_large, 1u);
+    EXPECT_GE(threads_large, threads_small);
 
     std::cout << "  - Platform-aware adaptive features: PASSED" << std::endl;
+}
 
-    // Test 7: Execution policy detection and fallback verification
-    std::cout << "Test 7: Execution policy detection" << std::endl;
-
-    bool has_std_exec = stats::arch::has_execution_policies();
-    std::cout << "  - Standard execution policies available: " << (has_std_exec ? "YES" : "NO")
-              << std::endl;
+TEST(ParallelExecutionComprehensive, ExecutionPolicyDetection) {
+    [[maybe_unused]] bool has_std_exec = stats::arch::has_execution_policies();
+    std::cout << "  - Standard execution policies: " << (has_std_exec ? "YES" : "NO") << std::endl;
     std::cout << "  - Execution support: " << stats::arch::execution_support_string() << std::endl;
+}
 
-#if defined(LIBSTATS_HAS_GCD)
-    std::cout << "  - GCD fallback available: YES" << std::endl;
-#elif defined(LIBSTATS_HAS_WIN_THREADPOOL)
-    std::cout << "  - Windows Thread Pool API available: YES" << std::endl;
-#elif defined(LIBSTATS_HAS_OPENMP)
-    std::cout << "  - OpenMP available: YES" << std::endl;
-#elif defined(LIBSTATS_HAS_PTHREADS)
-    std::cout << "  - POSIX threads available: YES" << std::endl;
-#else
-    std::cout << "  - Only serial execution available" << std::endl;
-#endif
-
-    // Test threshold logic with various sizes
-    std::cout << "  - Threshold decisions:" << std::endl;
-    std::cout << "    * 10 elements: "
-              << (stats::arch::should_use_parallel(10) ? "parallel" : "serial") << std::endl;
-    std::cout << "    * 100 elements: "
-              << (stats::arch::should_use_parallel(100) ? "parallel" : "serial") << std::endl;
-    std::cout << "    * 1000 elements: "
-              << (stats::arch::should_use_parallel(1000) ? "parallel" : "serial") << std::endl;
-    std::cout << "    * 10000 elements: "
-              << (stats::arch::should_use_parallel(10000) ? "parallel" : "serial") << std::endl;
-
-    // Test 8: Platform-specific optimizations validation
-    std::cout << "Test 8: Platform-specific optimization validation" << std::endl;
-
-    // Test different grain sizes with different data sizes
-    std::vector<std::size_t> test_sizes = {1000, 10000, 100000};
-    for (auto size : test_sizes) {
-        auto adaptive_grain = stats::arch::get_adaptive_grain_size(0, size);
-        std::cout << "  - Data size " << size << ": adaptive grain = " << adaptive_grain
-                  << std::endl;
-
-        // Ensure grain size is reasonable
-        // Note: grain size can be larger than data size for small datasets
-        // This just means the entire dataset becomes a single chunk, which is fine
-        assert(adaptive_grain >= 32);  // Minimum reasonable grain size
+TEST(ParallelExecutionComprehensive, PlatformSpecificOptimizations) {
+    for (auto size : {1000u, 10000u, 100000u}) {
+        auto grain = stats::arch::get_adaptive_grain_size(0, size);
+        EXPECT_GE(grain, 32u);
+        std::cout << "  - Data size " << size << ": grain = " << grain << std::endl;
     }
+    EXPECT_GE(stats::arch::get_adaptive_grain_size(0, 1000000), 64u);
 
-    // Test GPU-accelerated grain sizing for memory operations
-    auto gpu_accelerated_grain = stats::arch::get_adaptive_grain_size(0, 1000000);  // 1M elements
-    std::cout << "  - GPU-accelerated grain (1M elements): " << gpu_accelerated_grain << std::endl;
-    assert(gpu_accelerated_grain >= 64);
-
-    // Test distribution parallel thresholds
-    bool should_parallel_small = stats::arch::should_use_distribution_parallel(100);
     bool should_parallel_large = stats::arch::should_use_distribution_parallel(100000);
-
-    std::cout << "  - Distribution parallel (100 elements): "
-              << (should_parallel_small ? "YES" : "NO") << std::endl;
-    std::cout << "  - Distribution parallel (100k elements): "
-              << (should_parallel_large ? "YES" : "NO") << std::endl;
-
-    // Large datasets should generally use parallel
     if (stats::arch::has_execution_policies()) {
-        assert(should_parallel_large);
+        EXPECT_TRUE(should_parallel_large);
     }
-
     std::cout << "  - Platform-specific optimization validation: PASSED" << std::endl;
-
-    std::cout << std::endl;
-    std::cout << "🎉 All comprehensive parallel execution tests passed!" << std::endl;
-    std::cout << "✅ GCD-specific implementations working correctly" << std::endl;
-    std::cout << "✅ Edge cases handled properly" << std::endl;
-    std::cout << "✅ Algorithm correctness verified" << std::endl;
-    std::cout << "✅ Performance characteristics acceptable" << std::endl;
-    std::cout << "✅ Memory and exception safety confirmed" << std::endl;
-    std::cout << "✅ Platform-aware adaptive features validated" << std::endl;
-    std::cout << "✅ Execution policy detection working" << std::endl;
-    std::cout << "✅ Platform-specific optimizations confirmed" << std::endl;
-
-    return 0;
 }

--- a/tests/test_parallel_execution_integration.cpp
+++ b/tests/test_parallel_execution_integration.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cassert>
 #include <iostream>
 #include <numeric>
 #include <vector>
@@ -8,88 +7,72 @@
 #define LIBSTATS_FULL_INTERFACE
 #include "libstats/libstats.h"
 
-int main() {
-    std::cout << "=== Testing parallel_execution.h Integration ===" << std::endl;
+#include <gtest/gtest.h>
 
-    // Test 1: Basic header inclusion (compilation test)
-    std::cout << "Test 1: Header inclusion - ";
-    std::cout << (stats::arch::has_execution_policies() ? "C++20 parallel execution available"
-                                                        : "Fallback to serial execution");
-    std::cout << std::endl;
+TEST(ParallelExecutionIntegration, HeaderAndThresholds) {
+    std::cout << "Header inclusion - "
+              << (stats::arch::has_execution_policies() ? "C++20 parallel execution available"
+                                                        : "Fallback to serial execution")
+              << std::endl;
 
-    // Test 2: CPU-aware threshold detection
-    std::cout << "Test 2: CPU-aware threshold detection - ";
     std::size_t optimal_threshold = stats::arch::get_min_elements_for_distribution_parallel();
     std::size_t optimal_grain = stats::arch::get_optimal_grain_size();
     std::cout << "Threshold: " << optimal_threshold << ", Grain: " << optimal_grain << std::endl;
+    EXPECT_GT(optimal_threshold, 0u);
+    EXPECT_GT(optimal_grain, 0u);
+}
 
-    // Test 3: Basic parallel algorithm functionality
-    std::cout << "Test 3: Basic parallel algorithm functionality" << std::endl;
-
-    // Test safe_fill
+TEST(ParallelExecutionIntegration, BasicAlgorithms) {
+    // safe_fill
     std::vector<double> data(1000);
     stats::arch::safe_fill(data.begin(), data.end(), 42.0);
-    assert(std::all_of(data.begin(), data.end(), [](double x) { return x == 42.0; }));
+    EXPECT_TRUE(std::all_of(data.begin(), data.end(), [](double x) { return x == 42.0; }));
     std::cout << "  - safe_fill: PASSED" << std::endl;
 
-    // Test safe_transform
+    // safe_transform
     std::vector<double> input(1000);
     std::vector<double> output(1000);
     std::iota(input.begin(), input.end(), 1.0);
     stats::arch::safe_transform(input.begin(), input.end(), output.begin(),
                                 [](double x) { return x * 2.0; });
-    assert(output[0] == 2.0 && output[999] == 2000.0);
+    EXPECT_EQ(output[0], 2.0);
+    EXPECT_EQ(output[999], 2000.0);
     std::cout << "  - safe_transform: PASSED" << std::endl;
 
-    // Test safe_reduce
+    // safe_reduce
     std::vector<double> values(100);
     std::fill(values.begin(), values.end(), 1.0);
-    [[maybe_unused]] double sum = stats::arch::safe_reduce(values.begin(), values.end(), 0.0);
-    assert(sum == 100.0);
+    double sum = stats::arch::safe_reduce(values.begin(), values.end(), 0.0);
+    EXPECT_EQ(sum, 100.0);
     std::cout << "  - safe_reduce: PASSED" << std::endl;
 
-    // Test safe_for_each
+    // safe_for_each
     std::vector<int> counters(10, 0);
     stats::arch::safe_for_each(counters.begin(), counters.end(), [](int& x) { x = 1; });
-    assert(std::all_of(counters.begin(), counters.end(), [](int x) { return x == 1; }));
+    EXPECT_TRUE(std::all_of(counters.begin(), counters.end(), [](int x) { return x == 1; }));
     std::cout << "  - safe_for_each: PASSED" << std::endl;
 
-    // Test safe_sort
+    // safe_sort
     std::vector<double> unsorted = {5.0, 2.0, 8.0, 1.0, 9.0, 3.0};
     stats::arch::safe_sort(unsorted.begin(), unsorted.end());
-    assert(std::is_sorted(unsorted.begin(), unsorted.end()));
+    EXPECT_TRUE(std::is_sorted(unsorted.begin(), unsorted.end()));
     std::cout << "  - safe_sort: PASSED" << std::endl;
+}
 
-    // Test 4: Threshold decision logic
-    std::cout << "Test 4: Threshold decision logic" << std::endl;
-    bool should_use_small = stats::arch::should_use_parallel(10);
-    bool should_use_large = stats::arch::should_use_parallel(10000);
-    bool should_use_dist = stats::arch::should_use_distribution_parallel(1000);
+TEST(ParallelExecutionIntegration, ThresholdDecisions) {
+    [[maybe_unused]] bool should_use_small = stats::arch::should_use_parallel(10);
+    [[maybe_unused]] bool should_use_large = stats::arch::should_use_parallel(10000);
+    [[maybe_unused]] bool should_use_dist  = stats::arch::should_use_distribution_parallel(1000);
+    std::cout << "  - Small (10): "     << (should_use_small ? "parallel" : "serial") << std::endl;
+    std::cout << "  - Large (10000): "  << (should_use_large ? "parallel" : "serial") << std::endl;
+    std::cout << "  - Dist (1000): "    << (should_use_dist  ? "parallel" : "serial") << std::endl;
+    // All queries must complete without crash; no strict direction requirement.
+}
 
-    std::cout << "  - Small dataset (10 elements): " << (should_use_small ? "parallel" : "serial")
-              << std::endl;
-    std::cout << "  - Large dataset (10000 elements): "
-              << (should_use_large ? "parallel" : "serial") << std::endl;
-    std::cout << "  - Distribution dataset (1000 elements): "
-              << (should_use_dist ? "parallel" : "serial") << std::endl;
-
-    // Test 5: Safety integration
-    std::cout << "Test 5: Safety integration" << std::endl;
-    try {
+TEST(ParallelExecutionIntegration, EmptyContainerSafety) {
+    EXPECT_NO_THROW({
         std::vector<double> empty_data;
         stats::arch::safe_fill(empty_data.begin(), empty_data.end(), 1.0);
-        std::cout << "  - Empty container handling: PASSED" << std::endl;
-    } catch (const std::exception&) {
-        std::cout << "  - Empty container handling: PASSED (caught expected exception)"
-                  << std::endl;
-    }
-
-    std::cout << std::endl;
-    std::cout << "🎉 All parallel_execution.h integration tests passed!" << std::endl;
-    std::cout << "✅ Header successfully integrated into libstats.h" << std::endl;
-    std::cout << "✅ CPU-aware optimization working" << std::endl;
-    std::cout << "✅ All parallel algorithms functioning correctly" << std::endl;
-    std::cout << "✅ Safety integration working" << std::endl;
-
-    return 0;
+    });
+    std::cout << "  - Empty container handling: PASSED" << std::endl;
 }

--- a/tests/test_platform_optimizations.cpp
+++ b/tests/test_platform_optimizations.cpp
@@ -17,7 +17,7 @@
 
 // Standard library includes
 #include <algorithm>  // for std::sort, std::min, std::max
-#include <cassert>    // for assert
+#include <gtest/gtest.h>
 #include <chrono>     // for std::chrono::high_resolution_clock
 #include <exception>  // for std::exception
 #include <iomanip>    // for std::setprecision
@@ -35,37 +35,15 @@ using namespace stats::arch;
 using namespace stats::arch::simd;
 using namespace std;
 
-// Test options structure
-struct TestOptions {
-    bool json = false;
-    bool help = false;
-    bool verbose = false;
-};
-
-// Forward declarations for test functions
-TestOptions parse_args(int argc, char* argv[]);
-void print_help();
-void output_json_summary();
-void test_basic_platform_info();
-void test_cache_aware_algorithms();
-void test_memory_access_patterns();
-void test_numa_aware_processing();
-void test_platform_constants_validation();
-void test_advanced_vectorization_decisions();
-void test_cross_architecture_consistency();
-void test_simd_threshold_alignment();
-void test_performance_scaling();
-void test_adaptive_optimization();
+// Forward declarations for benchmark helpers
 void benchmark_cache_blocking();
 void benchmark_memory_bandwidth();
 
-// Helper functions
 template <typename T>
 void fill_random_data(vector<T>& data, T min_val = T(0), T max_val = T(1)) {
     random_device rd;
     mt19937 gen(rd());
     uniform_real_distribution<T> dis(min_val, max_val);
-
     for (auto& val : data) {
         val = dis(gen);
     }
@@ -86,112 +64,12 @@ size_t get_l3_cache_elements() {
     return features.l3_cache.size / sizeof(double);
 }
 
-// Global variables for test tracking
-struct TestResults {
-    bool basic_platform_info = false;
-    bool platform_constants_validation = false;
-    bool advanced_vectorization_decisions = false;
-    bool simd_threshold_alignment = false;
-    bool cache_aware_algorithms = false;
-    bool memory_access_patterns = false;
-    bool numa_aware_processing = false;
-    bool cross_architecture_consistency = false;
-    bool performance_scaling = false;
-    bool adaptive_optimization = false;
-
-    bool all_passed() const {
-        return basic_platform_info && platform_constants_validation &&
-               advanced_vectorization_decisions && simd_threshold_alignment &&
-               cache_aware_algorithms && memory_access_patterns && numa_aware_processing &&
-               cross_architecture_consistency && performance_scaling && adaptive_optimization;
-    }
-};
-
-static TestResults g_test_results;
-static TestOptions g_options;
-
-int main(int argc, char* argv[]) {
-    g_options = parse_args(argc, argv);
-
-    if (g_options.help) {
-        print_help();
-        return 0;
-    }
-
-    if (!g_options.json) {
-        cout << "=== COMPREHENSIVE PLATFORM OPTIMIZATION TEST SUITE ===" << endl;
-        cout << "=======================================================" << endl;
-    }
-
-    // Prepare to optionally silence stdout during test execution in JSON mode
-    std::streambuf* old_buf = nullptr;
-    struct NullBuffer : std::streambuf {
-        int overflow(int c) override { return c; }
-    } null_buf;
-    if (g_options.json && !g_options.verbose) {
-        old_buf = cout.rdbuf(&null_buf);
-    }
-
-    try {
-        test_basic_platform_info();
-        g_test_results.basic_platform_info = true;
-
-        test_platform_constants_validation();
-        g_test_results.platform_constants_validation = true;
-
-        test_advanced_vectorization_decisions();
-        g_test_results.advanced_vectorization_decisions = true;
-
-        test_simd_threshold_alignment();
-        g_test_results.simd_threshold_alignment = true;
-
-        test_cache_aware_algorithms();
-        g_test_results.cache_aware_algorithms = true;
-
-        test_memory_access_patterns();
-        g_test_results.memory_access_patterns = true;
-
-        test_numa_aware_processing();
-        g_test_results.numa_aware_processing = true;
-
-        test_cross_architecture_consistency();
-        g_test_results.cross_architecture_consistency = true;
-
-        test_performance_scaling();
-        g_test_results.performance_scaling = true;
-
-        test_adaptive_optimization();
-        g_test_results.adaptive_optimization = true;
-
-        if (g_options.json) {
-            // Restore stdout before printing JSON
-            if (old_buf)
-                cout.rdbuf(old_buf);
-            output_json_summary();
-        } else {
-            cout << "\n=== ALL PLATFORM OPTIMIZATION TESTS PASSED SUCCESSFULLY ===" << endl;
-        }
-        return 0;
-
-    } catch (const exception& e) {
-        if (g_options.json) {
-            // Restore stdout before printing JSON
-            if (old_buf)
-                cout.rdbuf(old_buf);
-            output_json_summary();
-        } else {
-            cerr << "\nError in platform optimization tests: " << e.what() << endl;
-        }
-        return 1;
-    }
-}
-
 void test_basic_platform_info() {
     cout << "\n=== BASIC PLATFORM INFORMATION ===" << endl;
 
     // Test platform optimization info
     string platform_info = VectorOps::get_platform_optimization_info();
-    assert(!platform_info.empty());
+    EXPECT_TRUE(!platform_info.empty());
     cout << "✓ Platform info: " << platform_info << endl;
 
     // Test platform capabilities
@@ -205,10 +83,10 @@ void test_basic_platform_info() {
     cout << "  - Optimal alignment: " << stats::arch::optimal_alignment() << " bytes" << endl;
 
     // Verify basic consistency
-    assert(VectorOps::supports_vectorization());
-    assert(VectorOps::double_vector_width() > 0);
-    assert(float_vector_width() > 0);
-    assert(stats::arch::optimal_alignment() > 0 &&
+    EXPECT_TRUE(VectorOps::supports_vectorization());
+    EXPECT_TRUE(VectorOps::double_vector_width() > 0);
+    EXPECT_TRUE(float_vector_width() > 0);
+    EXPECT_TRUE(stats::arch::optimal_alignment() > 0 &&
            (stats::arch::optimal_alignment() & (stats::arch::optimal_alignment() - 1)) == 0);
 }
 
@@ -224,12 +102,12 @@ void test_platform_constants_validation() {
     auto prefetch_dist = tuned::prefetch_distance();
 
     // Validate ranges
-    assert(matrix_block > 0 && matrix_block <= 512);     // Reasonable matrix block sizes
-    assert(simd_width > 0 && simd_width <= 64);          // Reasonable SIMD widths
-    assert(min_threshold > 0 && min_threshold <= 1024);  // Reasonable SIMD threshold
-    assert(cache_step > 0);
-    assert(l1_doubles > 1000);  // At least 8KB worth of doubles
-    assert(prefetch_dist > 0 && prefetch_dist <= 512);
+    EXPECT_TRUE(matrix_block > 0 && matrix_block <= 512);     // Reasonable matrix block sizes
+    EXPECT_TRUE(simd_width > 0 && simd_width <= 64);          // Reasonable SIMD widths
+    EXPECT_TRUE(min_threshold > 0 && min_threshold <= 1024);  // Reasonable SIMD threshold
+    EXPECT_TRUE(cache_step > 0);
+    EXPECT_TRUE(l1_doubles > 1000);  // At least 8KB worth of doubles
+    EXPECT_TRUE(prefetch_dist > 0 && prefetch_dist <= 512);
 
     cout << "✓ Platform constants validation:" << endl;
     cout << "  - Matrix block size: " << matrix_block << " (valid range)" << endl;
@@ -240,8 +118,8 @@ void test_platform_constants_validation() {
     cout << "  - Prefetch distance: " << prefetch_dist << endl;
 
     // Cross-validate constants make sense together
-    assert(matrix_block >= simd_width);                 // Block size should be at least SIMD width
-    assert(l1_doubles >= matrix_block * matrix_block);  // L1 should fit matrix blocks
+    EXPECT_TRUE(matrix_block >= simd_width);                 // Block size should be at least SIMD width
+    EXPECT_TRUE(l1_doubles >= matrix_block * matrix_block);  // L1 should fit matrix blocks
 
     cout << "✓ Cross-validation of constants passed" << endl;
 }
@@ -262,7 +140,7 @@ void test_advanced_vectorization_decisions() {
 
         // Large sizes should definitely use SIMD
         if (size >= 1024) {
-            assert(should_vectorize);
+            EXPECT_TRUE(should_vectorize);
         }
     }
 
@@ -273,13 +151,13 @@ void test_advanced_vectorization_decisions() {
     bool null_decision = VectorOps::should_use_vectorized_path(100, nullptr);
     cout << "  Null pointer: " << (null_decision ? "SIMD" : "Scalar") << " (should be Scalar)"
          << endl;
-    assert(!null_decision);
+    EXPECT_TRUE(!null_decision);
 
     // Zero size should return false
     vector<double> dummy_data(10);
     bool zero_decision = VectorOps::should_use_vectorized_path(0, dummy_data.data());
     cout << "  Zero size: " << (zero_decision ? "SIMD" : "Scalar") << " (should be Scalar)" << endl;
-    assert(!zero_decision);
+    EXPECT_TRUE(!zero_decision);
 
     cout << "✓ Advanced vectorization decisions passed" << endl;
 }
@@ -404,7 +282,7 @@ void test_memory_access_patterns() {
     vector<double, aligned_allocator<double>> aligned_data(1024, 1.0);
     bool alignment_check = is_aligned(aligned_data.data());
     cout << "  Aligned allocator: " << (alignment_check ? "PASS" : "FAIL") << endl;
-    assert(alignment_check);
+    EXPECT_TRUE(alignment_check);
 
     // Test SIMD operations on aligned vs unaligned data
     vector<double> unaligned_data(1024, 1.0);
@@ -507,12 +385,12 @@ void test_numa_aware_processing() {
     cout << "  Default grain size: " << grain_size << endl;
 
     // Thresholds should be reasonable for the number of cores
-    assert(min_parallel > 0);
-    assert(grain_size > 0);
+    EXPECT_TRUE(min_parallel > 0);
+    EXPECT_TRUE(grain_size > 0);
     // Note: grain_size can be larger than min_parallel for efficiency
     // Each thread should work on grain_size elements, while min_parallel
     // is just the threshold to start using parallel processing
-    assert(grain_size >= min_parallel / 32);  // Reasonable lower bound check
+    EXPECT_TRUE(grain_size >= min_parallel / 32);  // Reasonable lower bound check
 
     cout << "✓ NUMA-aware processing validation completed" << endl;
 }
@@ -536,15 +414,15 @@ void test_cross_architecture_consistency() {
     cout << "  Memory alignment: " << alignment << " bytes" << endl;
 
     // Consistency checks
-    assert(double_width > 0);
-    assert(float_width > 0);
-    assert(float_width >= double_width);                          // Floats should pack more densely
-    assert(alignment > 0 && (alignment & (alignment - 1)) == 0);  // Power of 2
+    EXPECT_TRUE(double_width > 0);
+    EXPECT_TRUE(float_width > 0);
+    EXPECT_TRUE(float_width >= double_width);                          // Floats should pack more densely
+    EXPECT_TRUE(alignment > 0 && (alignment & (alignment - 1)) == 0);  // Power of 2
 
     // Platform-specific validation
     if (features.vendor == "Apple") {
         cout << "\nApple Silicon specific checks:" << endl;
-        assert(features.neon);  // Apple Silicon should have NEON
+        EXPECT_TRUE(features.neon);  // Apple Silicon should have NEON
         cout << "  ✓ NEON support confirmed" << endl;
 
         // Apple Silicon typically has lower thread creation overhead
@@ -555,11 +433,11 @@ void test_cross_architecture_consistency() {
     } else if (features.vendor == "GenuineIntel") {
         cout << "\nIntel specific checks:" << endl;
         if (features.avx2) {
-            assert(double_width >= 4);  // AVX2 should give at least 256-bit vectors
+            EXPECT_TRUE(double_width >= 4);  // AVX2 should give at least 256-bit vectors
             cout << "  ✓ AVX2 vector width confirmed" << endl;
         }
         if (features.avx512f) {
-            assert(double_width >= 8);  // AVX-512 should give 512-bit vectors
+            EXPECT_TRUE(double_width >= 8);  // AVX-512 should give 512-bit vectors
             cout << "  ✓ AVX-512 vector width confirmed" << endl;
         }
 
@@ -576,7 +454,7 @@ void test_cross_architecture_consistency() {
     VectorOps::scalar_multiply(consistency_test.data(), 2.0, consistency_test.data(), 16);
 
     // Verify the operation worked
-    assert(abs(consistency_test[0] - 2.0) < 1e-10);
+    EXPECT_TRUE(abs(consistency_test[0] - 2.0) < 1e-10);
 
     cout << "✓ Cross-architecture consistency validation completed" << endl;
 }
@@ -668,7 +546,7 @@ void test_adaptive_optimization() {
     cout << "  Min SIMD threshold: " << min_simd_elements << " elements" << endl;
 
     // Minimum should be some multiple of SIMD width
-    assert(min_simd_elements >= simd_width);
+    EXPECT_TRUE(min_simd_elements >= simd_width);
     cout << "  ✓ SIMD threshold aligns with vector width" << endl;
 
     // Thread-based adaptations
@@ -792,139 +670,14 @@ void benchmark_memory_bandwidth() {
     }
 }
 
-// Command-line parsing implementation
-TestOptions parse_args(int argc, char* argv[]) {
-    TestOptions options;
 
-    for (int i = 1; i < argc; ++i) {
-        string arg = argv[i];
-        if (arg == "--json" || arg == "-j") {
-            options.json = true;
-        } else if (arg == "--help" || arg == "-h") {
-            options.help = true;
-        } else if (arg == "--verbose" || arg == "-v") {
-            options.verbose = true;
-        } else {
-            cerr << "Unknown option: " << arg << endl;
-            options.help = true;
-        }
-    }
-
-    return options;
-}
-
-// Help text implementation
-void print_help() {
-    cout << "Platform Optimization Test Suite" << endl;
-    cout << "\nUsage: test_platform_optimizations [options]" << endl;
-    cout << "\nOptions:" << endl;
-    cout << "  -j, --json      Output results in JSON format for CI integration" << endl;
-    cout << "  -v, --verbose   Enable verbose output (currently same as default)" << endl;
-    cout << "  -h, --help      Show this help message" << endl;
-    cout << "\nThis test suite validates platform-specific optimizations including:" << endl;
-    cout << "  - Cache-aware algorithms and blocking strategies" << endl;
-    cout << "  - NUMA-aware processing validation" << endl;
-    cout << "  - Platform-specific constants validation" << endl;
-    cout << "  - Memory access pattern optimization" << endl;
-    cout << "  - SIMD consistency and threshold alignment" << endl;
-    cout << "  - Cross-architecture performance comparison" << endl;
-    cout << "  - Advanced vectorization decision testing" << endl;
-    cout << "  - Performance scaling analysis" << endl;
-    cout << "  - Adaptive optimization validation" << endl;
-}
-
-// JSON output implementation
-void output_json_summary() {
-    const auto& features = get_features();
-
-    cout << "{" << endl;
-    cout << "  \"test_name\": \"platform_optimizations\"," << endl;
-    cout << "  \"version\": \"1.0\"," << endl;
-    cout << "  \"timestamp\": \""
-         << chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch())
-                .count()
-         << "\"," << endl;
-
-    // Test status
-    cout << "  \"test_status\": {" << endl;
-    cout << "    \"overall_pass\": " << (g_test_results.all_passed() ? "true" : "false") << ","
-         << endl;
-    cout << "    \"basic_platform_info\": "
-         << (g_test_results.basic_platform_info ? "true" : "false") << "," << endl;
-    cout << "    \"platform_constants_validation\": "
-         << (g_test_results.platform_constants_validation ? "true" : "false") << "," << endl;
-    cout << "    \"advanced_vectorization_decisions\": "
-         << (g_test_results.advanced_vectorization_decisions ? "true" : "false") << "," << endl;
-    cout << "    \"simd_threshold_alignment\": "
-         << (g_test_results.simd_threshold_alignment ? "true" : "false") << "," << endl;
-    cout << "    \"cache_aware_algorithms\": "
-         << (g_test_results.cache_aware_algorithms ? "true" : "false") << "," << endl;
-    cout << "    \"memory_access_patterns\": "
-         << (g_test_results.memory_access_patterns ? "true" : "false") << "," << endl;
-    cout << "    \"numa_aware_processing\": "
-         << (g_test_results.numa_aware_processing ? "true" : "false") << "," << endl;
-    cout << "    \"cross_architecture_consistency\": "
-         << (g_test_results.cross_architecture_consistency ? "true" : "false") << "," << endl;
-    cout << "    \"performance_scaling\": "
-         << (g_test_results.performance_scaling ? "true" : "false") << "," << endl;
-    cout << "    \"adaptive_optimization\": "
-         << (g_test_results.adaptive_optimization ? "true" : "false") << "," << endl;
-    cout << "    \"exit_code\": " << (g_test_results.all_passed() ? "0" : "1") << endl;
-    cout << "  }," << endl;
-
-    // Platform information
-    cout << "  \"platform_info\": {" << endl;
-    cout << "    \"cpu_vendor\": \"" << features.vendor << "\"," << endl;
-    cout << "    \"architecture\": \"" << best_simd_level() << "\"," << endl;
-    cout << "    \"simd_level\": \"" << VectorOps::get_active_simd_level() << "\"," << endl;
-    cout << "    \"double_vector_width\": " << VectorOps::double_vector_width() << "," << endl;
-    cout << "    \"float_vector_width\": " << float_vector_width() << "," << endl;
-    cout << "    \"optimal_alignment\": " << stats::arch::optimal_alignment() << "," << endl;
-    cout << "    \"supports_vectorization\": "
-         << (VectorOps::supports_vectorization() ? "true" : "false") << "," << endl;
-    cout << "    \"physical_cores\": " << features.topology.physical_cores << "," << endl;
-    cout << "    \"logical_cores\": " << features.topology.logical_cores << "," << endl;
-    cout << "    \"cpu_packages\": " << features.topology.packages << "," << endl;
-    cout << "    \"hyperthreading\": " << (features.topology.hyperthreading ? "true" : "false")
-         << endl;
-    cout << "  }," << endl;
-
-    // Cache information
-    cout << "  \"cache_info\": {" << endl;
-    cout << "    \"l1_data_size\": " << features.l1_data_cache.size << "," << endl;
-    cout << "    \"l1_instruction_size\": " << features.l1_instruction_cache.size << "," << endl;
-    cout << "    \"l2_size\": " << features.l2_cache.size << "," << endl;
-    cout << "    \"l3_size\": " << features.l3_cache.size << "," << endl;
-    cout << "    \"cache_line_size\": " << features.cache_line_size << endl;
-    cout << "  }," << endl;
-
-    // Platform optimization thresholds
-    cout << "  \"optimization_thresholds\": {" << endl;
-    cout << "    \"min_simd_size\": " << VectorOps::min_simd_size() << "," << endl;
-    cout << "    \"simd_policy_threshold\": " << SIMDPolicy::getMinThreshold() << "," << endl;
-    cout << "    \"matrix_block_size\": " << tuned::matrix_block_size() << "," << endl;
-    cout << "    \"simd_loop_width\": " << tuned::simd_loop_width() << "," << endl;
-    cout << "    \"cache_friendly_step\": " << tuned::cache_friendly_step() << "," << endl;
-    cout << "    \"l1_cache_doubles\": " << tuned::l1_cache_doubles() << "," << endl;
-    cout << "    \"prefetch_distance\": " << tuned::prefetch_distance() << "," << endl;
-    cout << "    \"min_elements_for_parallel\": " << get_min_elements_for_parallel() << "," << endl;
-    cout << "    \"default_grain_size\": " << get_default_grain_size() << "," << endl;
-    cout << "    \"optimal_block_size\": " << VectorOps::get_optimal_block_size() << endl;
-    cout << "  }," << endl;
-
-    // Feature flags
-    cout << "  \"feature_flags\": {" << endl;
-    cout << "    \"sse2\": " << (features.sse2 ? "true" : "false") << "," << endl;
-    cout << "    \"sse3\": " << (features.sse3 ? "true" : "false") << "," << endl;
-    cout << "    \"ssse3\": " << (features.ssse3 ? "true" : "false") << "," << endl;
-    cout << "    \"sse4_1\": " << (features.sse4_1 ? "true" : "false") << "," << endl;
-    cout << "    \"sse4_2\": " << (features.sse4_2 ? "true" : "false") << "," << endl;
-    cout << "    \"avx\": " << (features.avx ? "true" : "false") << "," << endl;
-    cout << "    \"avx2\": " << (features.avx2 ? "true" : "false") << "," << endl;
-    cout << "    \"avx512f\": " << (features.avx512f ? "true" : "false") << "," << endl;
-    cout << "    \"fma\": " << (features.fma ? "true" : "false") << "," << endl;
-    cout << "    \"neon\": " << (features.neon ? "true" : "false") << endl;
-    cout << "  }" << endl;
-
-    cout << "}" << endl;
-}
+TEST(PlatformOptimizations, BasicPlatformInfo)           { test_basic_platform_info(); }
+TEST(PlatformOptimizations, PlatformConstantsValidation) { test_platform_constants_validation(); }
+TEST(PlatformOptimizations, AdvancedVectorizationDecisions){ test_advanced_vectorization_decisions(); }
+TEST(PlatformOptimizations, SimdThresholdAlignment)      { test_simd_threshold_alignment(); }
+TEST(PlatformOptimizations, CacheAwareAlgorithms)        { test_cache_aware_algorithms(); }
+TEST(PlatformOptimizations, MemoryAccessPatterns)        { test_memory_access_patterns(); }
+TEST(PlatformOptimizations, NumaAwareProcessing)         { test_numa_aware_processing(); }
+TEST(PlatformOptimizations, CrossArchitectureConsistency){ test_cross_architecture_consistency(); }
+TEST(PlatformOptimizations, PerformanceScaling)          { test_performance_scaling(); }
+TEST(PlatformOptimizations, AdaptiveOptimization)        { test_adaptive_optimization(); }

--- a/tests/test_simd_policy.cpp
+++ b/tests/test_simd_policy.cpp
@@ -20,7 +20,7 @@
 
 // Standard library includes
 #include <algorithm>  // for std::sort, std::min, std::max
-#include <cassert>    // for assert
+#include <gtest/gtest.h>
 #include <cmath>      // for mathematical functions
 #include <iostream>   // for std::cout, std::cerr, std::endl
 #include <string>     // for std::string
@@ -32,86 +32,11 @@ using namespace stats::arch::simd;
 // COMMAND-LINE ARGUMENT PARSING
 //==============================================================================
 
-struct TestOptions {
-    bool test_all = false;
-    bool test_policy = false;
-    bool test_detection = false;
-    bool test_thresholds = false;
-    bool test_alignment = false;
-    bool test_capabilities = false;
-    bool test_consistency = false;
-    bool test_stress = false;
-    bool show_help = false;
-};
+;
 
-void print_help() {
-    std::cout << "Usage: test_simd_policy [options]\n\n";
-    std::cout << "Test platform/simd_policy.h centralized SIMD abstraction:\n\n";
-    std::cout << "Options:\n";
-    std::cout << "  --all/-a           Test all SIMD policy components (default)\n";
-    std::cout << "  --policy/-p        Test core policy decisions (shouldUseSIMD)\n";
-    std::cout << "  --detection/-d     Test SIMD level detection\n";
-    std::cout << "  --thresholds/-t    Test threshold calculations\n";
-    std::cout << "  --alignment/-A     Test alignment requirements\n";
-    std::cout << "  --capabilities/-c  Test capability reporting\n";
-    std::cout << "  --consistency/-C   Test cross-platform consistency\n";
-    std::cout << "  --stress/-s        Run stress tests with various data sizes\n";
-    std::cout << "  --help/-h          Show this help\n\n";
-    std::cout << "Examples:\n";
-    std::cout << "  test_simd_policy                    # Test all components\n";
-    std::cout << "  test_simd_policy --policy --detection # Test core policy and detection\n";
-    std::cout << "  test_simd_policy -t -A              # Test thresholds and alignment\n";
-    std::cout << "  test_simd_policy --stress            # Run stress tests\n";
-}
 
-TestOptions parse_arguments(int argc, char* argv[]) {
-    TestOptions options;
-    bool any_specific_test = false;
 
-    for (int i = 1; i < argc; ++i) {
-        std::string arg(argv[i]);
 
-        if (arg == "--all" || arg == "-a") {
-            options.test_all = true;
-        } else if (arg == "--policy" || arg == "-p") {
-            options.test_policy = true;
-            any_specific_test = true;
-        } else if (arg == "--detection" || arg == "-d") {
-            options.test_detection = true;
-            any_specific_test = true;
-        } else if (arg == "--thresholds" || arg == "-t") {
-            options.test_thresholds = true;
-            any_specific_test = true;
-        } else if (arg == "--alignment" || arg == "-A") {
-            options.test_alignment = true;
-            any_specific_test = true;
-        } else if (arg == "--capabilities" || arg == "-c") {
-            options.test_capabilities = true;
-            any_specific_test = true;
-        } else if (arg == "--consistency" || arg == "-C") {
-            options.test_consistency = true;
-            any_specific_test = true;
-        } else if (arg == "--stress" || arg == "-s") {
-            options.test_stress = true;
-            any_specific_test = true;
-        } else if (arg == "--help" || arg == "-h") {
-            options.show_help = true;
-            return options;
-        } else {
-            std::cerr << "Unknown option: " << arg << "\n";
-            std::cerr << "Use --help/-h for usage information.\n";
-            options.show_help = true;
-            return options;
-        }
-    }
-
-    // If no specific tests requested, default to all
-    if (!any_specific_test && !options.test_all) {
-        options.test_all = true;
-    }
-
-    return options;
-}
 
 //==============================================================================
 // HELPER FUNCTIONS
@@ -168,13 +93,13 @@ void test_core_policy_decisions() {
 
         // Validate logical consistency
         if (threshold > 1) {
-            assert(!below_threshold ||
+            EXPECT_TRUE(!below_threshold ||
                    threshold <= 1);  // Below threshold should be false (unless threshold is 1)
         }
-        assert(at_threshold ||
+        EXPECT_TRUE(at_threshold ||
                SIMDPolicy::getBestLevel() ==
                    SIMDPolicy::Level::None);  // At threshold should be true unless no SIMD
-        assert(above_threshold ||
+        EXPECT_TRUE(above_threshold ||
                SIMDPolicy::getBestLevel() ==
                    SIMDPolicy::Level::None);  // Above threshold should be true unless no SIMD
 
@@ -202,7 +127,7 @@ void test_core_policy_decisions() {
                 found_simd = true;
             } else if (found_simd) {
                 // Once we decide to use SIMD, we shouldn't go back to scalar for larger sizes
-                assert(false && "SIMD policy should be monotonic");
+                ADD_FAILURE() << "SIMD policy should be monotonic";
             }
         }
 
@@ -221,12 +146,12 @@ void test_simd_level_detection() {
         std::string level_str = SIMDPolicy::getLevelString();
 
         // Level should be valid
-        assert(detected_level >= SIMDPolicy::Level::None);
-        assert(detected_level <= SIMDPolicy::Level::AVX512);
+        EXPECT_TRUE(detected_level >= SIMDPolicy::Level::None);
+        EXPECT_TRUE(detected_level <= SIMDPolicy::Level::AVX512);
 
         // Level string should not be empty and should match
-        assert(!level_str.empty());
-        assert(level_str == level_to_string(detected_level));
+        EXPECT_TRUE(!level_str.empty());
+        EXPECT_TRUE(level_str == level_to_string(detected_level));
 
         std::cout << "   ✓ Basic level detection passed\n";
         std::cout << "     Detected level: " << level_str << "\n";
@@ -270,7 +195,7 @@ void test_simd_level_detection() {
             expected_level = SIMDPolicy::Level::NEON;
         }
 #endif
-        assert(policy_level == expected_level);
+        EXPECT_TRUE(policy_level == expected_level);
 
         std::cout << "   ✓ Level consistency with CPU detection passed\n";
         std::cout << "     CPU AVX512: " << (cpu_supports_avx512 ? "YES" : "NO") << "\n";
@@ -287,7 +212,7 @@ void test_simd_level_detection() {
         [[maybe_unused]] SIMDPolicy::Level level_after = SIMDPolicy::getBestLevel();
 
         // Should be the same after refresh (CPU didn't change)
-        assert(level_before == level_after);
+        EXPECT_TRUE(level_before == level_after);
 
         std::cout << "   ✓ Cache refresh functionality passed\n";
     }
@@ -303,16 +228,16 @@ void test_threshold_calculations() {
         std::size_t threshold = SIMDPolicy::getMinThreshold();
 
         // Threshold should be reasonable
-        assert(threshold > 0);
-        assert(threshold <= 10000);  // Should be reasonable, not excessive
+        EXPECT_TRUE(threshold > 0);
+        EXPECT_TRUE(threshold <= 10000);  // Should be reasonable, not excessive
 
         // Should be consistent with policy decisions
         if (threshold > 1) {
-            assert(!SIMDPolicy::shouldUseSIMD(threshold - 1));
+            EXPECT_TRUE(!SIMDPolicy::shouldUseSIMD(threshold - 1));
         }
-        assert(SIMDPolicy::shouldUseSIMD(threshold) ||
+        EXPECT_TRUE(SIMDPolicy::shouldUseSIMD(threshold) ||
                SIMDPolicy::getBestLevel() == SIMDPolicy::Level::None);
-        assert(SIMDPolicy::shouldUseSIMD(threshold + 100) ||
+        EXPECT_TRUE(SIMDPolicy::shouldUseSIMD(threshold + 100) ||
                SIMDPolicy::getBestLevel() == SIMDPolicy::Level::None);
 
         std::cout << "   ✓ Basic threshold properties passed\n";
@@ -328,15 +253,15 @@ void test_threshold_calculations() {
         // (since setup cost is amortized better)
         if (level == SIMDPolicy::Level::None) {
             // No SIMD means threshold is irrelevant, but should still be valid
-            assert(threshold > 0);
+            EXPECT_TRUE(threshold > 0);
         } else {
             // SIMD available, threshold should be reasonable for the level
             if (level >= SIMDPolicy::Level::AVX2) {
-                assert(threshold <= 64);  // AVX2+ should have low threshold
+                EXPECT_TRUE(threshold <= 64);  // AVX2+ should have low threshold
             } else if (level >= SIMDPolicy::Level::AVX || level == SIMDPolicy::Level::NEON) {
-                assert(threshold <= 128);  // AVX/NEON should have moderate threshold
+                EXPECT_TRUE(threshold <= 128);  // AVX/NEON should have moderate threshold
             } else {
-                assert(threshold <= 256);  // SSE2 might have higher threshold
+                EXPECT_TRUE(threshold <= 256);  // SSE2 might have higher threshold
             }
         }
 
@@ -356,11 +281,11 @@ void test_alignment_requirements() {
         std::size_t alignment = SIMDPolicy::getOptimalAlignment();
 
         // Alignment should be a power of 2
-        assert(is_power_of_2(alignment));
+        EXPECT_TRUE(is_power_of_2(alignment));
 
         // Alignment should be reasonable (between 4 and 64 bytes typically)
-        assert(alignment >= 4);
-        assert(alignment <= 128);
+        EXPECT_TRUE(alignment >= 4);
+        EXPECT_TRUE(alignment <= 128);
 
         std::cout << "   ✓ Basic alignment properties passed\n";
         std::cout << "     Optimal alignment: " << alignment << " bytes\n";
@@ -374,18 +299,18 @@ void test_alignment_requirements() {
         // Validate alignment matches expected values for each SIMD level
         switch (level) {
             case SIMDPolicy::Level::AVX512:
-                assert(alignment >= 64);  // AVX-512 typically wants 64-byte alignment
+                EXPECT_TRUE(alignment >= 64);  // AVX-512 typically wants 64-byte alignment
                 break;
             case SIMDPolicy::Level::AVX2:
             case SIMDPolicy::Level::AVX:
-                assert(alignment >= 32);  // AVX typically wants 32-byte alignment
+                EXPECT_TRUE(alignment >= 32);  // AVX typically wants 32-byte alignment
                 break;
             case SIMDPolicy::Level::SSE2:
             case SIMDPolicy::Level::NEON:
-                assert(alignment >= 16);  // SSE2/NEON typically want 16-byte alignment
+                EXPECT_TRUE(alignment >= 16);  // SSE2/NEON typically want 16-byte alignment
                 break;
             case SIMDPolicy::Level::None:
-                assert(alignment >= 4);  // Even scalar should have some alignment
+                EXPECT_TRUE(alignment >= 4);  // Even scalar should have some alignment
                 break;
         }
 
@@ -405,12 +330,12 @@ void test_capability_reporting() {
         std::string capability_str = SIMDPolicy::getCapabilityString();
 
         // Should not be empty
-        assert(!capability_str.empty());
+        EXPECT_TRUE(!capability_str.empty());
 
         // Should contain some expected information
         SIMDPolicy::Level level = SIMDPolicy::getBestLevel();
         std::string level_str = level_to_string(level);
-        assert(capability_str.find(level_str) != std::string::npos);
+        EXPECT_TRUE(capability_str.find(level_str) != std::string::npos);
 
         std::cout << "   ✓ Basic capability reporting passed\n";
         std::cout << "     Capabilities: " << capability_str << "\n";
@@ -421,25 +346,25 @@ void test_capability_reporting() {
         std::size_t block_size = SIMDPolicy::getOptimalBlockSize();
 
         // Block size should be reasonable
-        assert(block_size > 0);
-        assert(block_size <= 32);  // Should not be excessive
+        EXPECT_TRUE(block_size > 0);
+        EXPECT_TRUE(block_size <= 32);  // Should not be excessive
 
         // Block size should match SIMD level
         SIMDPolicy::Level level = SIMDPolicy::getBestLevel();
         switch (level) {
             case SIMDPolicy::Level::AVX512:
-                assert(block_size >= 8);  // 512-bit / 64-bit = 8 doubles
+                EXPECT_TRUE(block_size >= 8);  // 512-bit / 64-bit = 8 doubles
                 break;
             case SIMDPolicy::Level::AVX2:
             case SIMDPolicy::Level::AVX:
-                assert(block_size >= 4);  // 256-bit / 64-bit = 4 doubles
+                EXPECT_TRUE(block_size >= 4);  // 256-bit / 64-bit = 4 doubles
                 break;
             case SIMDPolicy::Level::SSE2:
             case SIMDPolicy::Level::NEON:
-                assert(block_size >= 2);  // 128-bit / 64-bit = 2 doubles
+                EXPECT_TRUE(block_size >= 2);  // 128-bit / 64-bit = 2 doubles
                 break;
             case SIMDPolicy::Level::None:
-                assert(block_size >= 1);  // Scalar processing
+                EXPECT_TRUE(block_size >= 1);  // Scalar processing
                 break;
         }
 
@@ -465,11 +390,11 @@ void test_cross_platform_consistency() {
         std::string capability_str = SIMDPolicy::getCapabilityString();
 
         // Basic sanity checks
-        assert(threshold > 0);
-        assert(block_size > 0);
-        assert(alignment > 0);
-        assert(!level_str.empty());
-        assert(!capability_str.empty());
+        EXPECT_TRUE(threshold > 0);
+        EXPECT_TRUE(block_size > 0);
+        EXPECT_TRUE(alignment > 0);
+        EXPECT_TRUE(!level_str.empty());
+        EXPECT_TRUE(!capability_str.empty());
 
         std::cout << "   ✓ API consistency test passed\n";
         std::cout << "     All APIs callable and return valid values\n";
@@ -484,18 +409,18 @@ void test_cross_platform_consistency() {
         // If we have SIMD capability, decisions should make sense
         if (level != SIMDPolicy::Level::None) {
             // Should use SIMD for data above threshold
-            assert(SIMDPolicy::shouldUseSIMD(threshold * 2));
-            assert(SIMDPolicy::shouldUseSIMD(threshold * 10));
+            EXPECT_TRUE(SIMDPolicy::shouldUseSIMD(threshold * 2));
+            EXPECT_TRUE(SIMDPolicy::shouldUseSIMD(threshold * 10));
 
             // Should generally not use SIMD for very small data (unless threshold is 1)
             if (threshold > 1) {
-                assert(!SIMDPolicy::shouldUseSIMD(1));
+                EXPECT_TRUE(!SIMDPolicy::shouldUseSIMD(1));
             }
         } else {
             // No SIMD capability - should never recommend SIMD
-            assert(!SIMDPolicy::shouldUseSIMD(1));
-            assert(!SIMDPolicy::shouldUseSIMD(1000));
-            assert(!SIMDPolicy::shouldUseSIMD(1000000));
+            EXPECT_TRUE(!SIMDPolicy::shouldUseSIMD(1));
+            EXPECT_TRUE(!SIMDPolicy::shouldUseSIMD(1000));
+            EXPECT_TRUE(!SIMDPolicy::shouldUseSIMD(1000000));
         }
 
         std::cout << "   ✓ Logical consistency test passed\n";
@@ -520,7 +445,7 @@ void test_stress_conditions() {
                 bool decision = SIMDPolicy::shouldUseSIMD(size);
                 (void)decision;  // Suppress unused variable warning
             } catch (...) {
-                assert(false && "shouldUseSIMD should not throw for any size_t value");
+                ADD_FAILURE() << "shouldUseSIMD should not throw for any size_t value";
             }
         }
 
@@ -540,8 +465,8 @@ void test_stress_conditions() {
             [[maybe_unused]] std::size_t threshold = SIMDPolicy::getMinThreshold();
 
             // Results should be consistent
-            assert(level == initial_level);
-            assert(threshold == SIMDPolicy::getMinThreshold());  // Should be cached/consistent
+            EXPECT_TRUE(level == initial_level);
+            EXPECT_TRUE(threshold == SIMDPolicy::getMinThreshold());  // Should be cached/consistent
 
             (void)decision;  // Suppress unused variable warning
         }
@@ -557,7 +482,7 @@ void test_stress_conditions() {
         for (int i = 0; i < num_refreshes; ++i) {
             SIMDPolicy::refreshCache();
             [[maybe_unused]] SIMDPolicy::Level level = SIMDPolicy::getBestLevel();
-            assert(level == initial_level);  // Should remain consistent
+            EXPECT_TRUE(level == initial_level);  // Should remain consistent
         }
 
         std::cout << "   ✓ Cache refresh stress test passed\n";
@@ -570,81 +495,11 @@ void test_stress_conditions() {
 // MAIN FUNCTION
 //==============================================================================
 
-int main(int argc, char* argv[]) {
-    TestOptions options = parse_arguments(argc, argv);
 
-    if (options.show_help) {
-        print_help();
-        return 0;
-    }
-
-    std::cout << "Testing platform/simd_policy.h centralized SIMD abstraction...\n\n";
-
-    int tests_run = 0;
-    int tests_passed = 0;
-
-    try {
-        // Run selected tests
-        if (options.test_all || options.test_policy) {
-            test_core_policy_decisions();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_detection) {
-            test_simd_level_detection();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_thresholds) {
-            test_threshold_calculations();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_alignment) {
-            test_alignment_requirements();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_capabilities) {
-            test_capability_reporting();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_consistency) {
-            test_cross_platform_consistency();
-            tests_run++;
-            tests_passed++;
-        }
-
-        if (options.test_all || options.test_stress) {
-            test_stress_conditions();
-            tests_run++;
-            tests_passed++;
-        }
-
-        // Print summary
-        std::cout << "=== Test Summary ===\n";
-        std::cout << "Tests run: " << tests_run << "\n";
-        std::cout << "Tests passed: " << tests_passed << "\n";
-
-        if (tests_passed == tests_run && tests_run > 0) {
-            std::cout << "✓ All SIMD policy tests passed!\n";
-            return 0;
-        } else if (tests_run == 0) {
-            std::cout << "No tests were run. Use --help for usage information.\n";
-            return 1;
-        } else {
-            std::cout << "✗ Some tests failed!\n";
-            return 1;
-        }
-
-    } catch (const std::exception& e) {
-        std::cerr << "Test failed with exception: " << e.what() << "\n";
-        return 1;
-    }
-}
+TEST(SimdPolicy, CorePolicyDecisions)      { test_core_policy_decisions(); }
+TEST(SimdPolicy, SimdLevelDetection)       { test_simd_level_detection(); }
+TEST(SimdPolicy, ThresholdCalculations)    { test_threshold_calculations(); }
+TEST(SimdPolicy, AlignmentRequirements)    { test_alignment_requirements(); }
+TEST(SimdPolicy, CapabilityReporting)      { test_capability_reporting(); }
+TEST(SimdPolicy, CrossPlatformConsistency) { test_cross_platform_consistency(); }
+TEST(SimdPolicy, StressConditions)         { test_stress_conditions(); }

--- a/tests/test_thread_pool.cpp
+++ b/tests/test_thread_pool.cpp
@@ -10,7 +10,7 @@
  */
 
 // Standard library includes
-#include <cassert>   // for assert
+#include <gtest/gtest.h>
 #include <chrono>    // for std::chrono::high_resolution_clock
 #include <cmath>     // for mathematical functions
 #include <future>    // for std::future, std::async
@@ -27,12 +27,11 @@
 using namespace stats;
 
 class ThreadPoolTest {
-   private:
+   public:
     static constexpr double TOLERANCE = 1e-9;
     static constexpr std::size_t LARGE_SIZE = 10000;
     static constexpr std::size_t SMALL_SIZE = 100;
 
-   public:
     void runAllTests() {
         std::cout << "=== Comprehensive ThreadPool Level 0-2 Integration Test ===" << std::endl;
 
@@ -51,10 +50,9 @@ class ThreadPoolTest {
         testDocumentationExamples();
 
         std::cout << "\n🎉 All ThreadPool Level 0-2 integration tests passed!" << std::endl;
-        std::cout << "✓ Priority #1 implementation is complete and working correctly" << std::endl;
+        std::cout << "  ✓ Priority #1 implementation is complete and working correctly" << std::endl;
     }
 
-   private:
     void testLevel0ConstantsIntegration() {
         std::cout << "\n=== Test 1: Level 0 Constants Integration ===" << std::endl;
 
@@ -72,11 +70,11 @@ class ThreadPoolTest {
         std::cout << "  Memory alignment: " << memoryAlignment << " bytes" << std::endl;
 
         // Verify constants are reasonable
-        assert(parallelThreshold > 0);
-        assert(distributionThreshold > 0);
-        assert(defaultGrainSize > 0);
-        assert(simdBlockSize > 0);
-        assert(memoryAlignment > 0);
+        EXPECT_TRUE(parallelThreshold > 0);
+        EXPECT_TRUE(distributionThreshold > 0);
+        EXPECT_TRUE(defaultGrainSize > 0);
+        EXPECT_TRUE(simdBlockSize > 0);
+        EXPECT_TRUE(memoryAlignment > 0);
 
         // Test that small arrays don't use parallelization
         std::vector<int> smallData(parallelThreshold - 1);
@@ -159,11 +157,11 @@ class ThreadPoolTest {
         // cacheLineSize is size_t (unsigned): zero means undetectable, not invalid
 
         // Optimal threads should always be at least 1
-        assert(optimalThreads > 0);
+        EXPECT_TRUE(optimalThreads > 0);
 
         // Test that hyperthreading affects thread count calculation
         if (features.topology.hyperthreading) {
-            assert(optimalThreads <= physicalCores);
+            EXPECT_TRUE(optimalThreads <= physicalCores);
         }
 
         std::cout << "  ✓ CPU detection integration working correctly" << std::endl;
@@ -184,9 +182,9 @@ class ThreadPoolTest {
         std::cout << "  Optimal alignment: " << alignment << " bytes" << std::endl;
 
         // Verify SIMD detection is working
-        assert(simdWidth > 0);
-        assert(floatWidth > 0);
-        assert(alignment > 0);
+        EXPECT_TRUE(simdWidth > 0);
+        EXPECT_TRUE(floatWidth > 0);
+        EXPECT_TRUE(alignment > 0);
 
         // Test that grain size alignment considers SIMD width
         auto grainSize = arch::get_default_grain_size();
@@ -194,8 +192,8 @@ class ThreadPoolTest {
         std::cout << "  Base grain size: " << grainSize << std::endl;
         std::cout << "  SIMD-aligned grain size: " << alignedGrainSize << std::endl;
 
-        assert(alignedGrainSize >= grainSize);
-        assert(alignedGrainSize % simdWidth == 0);
+        EXPECT_TRUE(alignedGrainSize >= grainSize);
+        EXPECT_TRUE(alignedGrainSize % simdWidth == 0);
 
         std::cout << "  ✓ SIMD awareness working correctly" << std::endl;
     }
@@ -216,11 +214,11 @@ class ThreadPoolTest {
             std::cout << "  Safe sqrt(-1): " << safeSqrtValue << std::endl;
 
             // Verify safety functions work
-            assert(std::isfinite(finiteValue));
-            assert(clampedProb <= 1.0);
-            assert(clampedProb >= 0.0);
-            assert(std::isfinite(safeExpValue));
-            assert(safeSqrtValue == 0.0);  // sqrt(-1) should return 0
+            EXPECT_TRUE(std::isfinite(finiteValue));
+            EXPECT_TRUE(clampedProb <= 1.0);
+            EXPECT_TRUE(clampedProb >= 0.0);
+            EXPECT_TRUE(std::isfinite(safeExpValue));
+            EXPECT_TRUE(safeSqrtValue == 0.0);  // sqrt(-1) should return 0
 
             // Test finite value checking
             detail::check_finite(finiteValue, "test value");
@@ -228,7 +226,7 @@ class ThreadPoolTest {
             std::cout << "  ✓ Safety integration working correctly" << std::endl;
         } catch (const std::exception& e) {
             std::cerr << "  ✗ Safety integration failed: " << e.what() << std::endl;
-            assert(false);
+            EXPECT_TRUE(false);
         }
     }
 
@@ -240,10 +238,10 @@ class ThreadPoolTest {
             auto success = VoidResult::ok(true);
             auto error = VoidResult::makeError(ValidationError::InvalidParameter, "Test error");
 
-            assert(success.isOk());
-            assert(!success.isError());
-            assert(!error.isOk());
-            assert(error.isError());
+            EXPECT_TRUE(success.isOk());
+            EXPECT_TRUE(!success.isError());
+            EXPECT_TRUE(!error.isOk());
+            EXPECT_TRUE(error.isError());
 
             std::cout << "  Success result: " << (success.isOk() ? "OK" : "Error") << std::endl;
             std::cout << "  Error result: " << (error.isError() ? "Error" : "OK") << std::endl;
@@ -251,13 +249,13 @@ class ThreadPoolTest {
 
             // Test error string conversion
             auto errorString = errorToString(ValidationError::InvalidParameter);
-            assert(!errorString.empty());
+            EXPECT_TRUE(!errorString.empty());
             std::cout << "  Error string: " << errorString << std::endl;
 
             std::cout << "  ✓ Error handling integration working correctly" << std::endl;
         } catch (const std::exception& e) {
             std::cerr << "  ✗ Error handling integration failed: " << e.what() << std::endl;
-            assert(false);
+            EXPECT_TRUE(false);
         }
     }
 
@@ -276,15 +274,15 @@ class ThreadPoolTest {
         std::cout << "  Task 1 result: " << result1 << std::endl;
         std::cout << "  Task 2 result: " << result2 << std::endl;
 
-        assert(result1 == 42);
-        assert(result2 == 42);
+        EXPECT_TRUE(result1 == 42);
+        EXPECT_TRUE(result2 == 42);
 
         // Test void task submission
         bool taskExecuted = false;
         pool.submitVoid([&taskExecuted]() { taskExecuted = true; });
         pool.waitForAll();
 
-        assert(taskExecuted);
+        EXPECT_TRUE(taskExecuted);
         std::cout << "  Void task executed: " << (taskExecuted ? "Yes" : "No") << std::endl;
 
         // Test pool properties
@@ -323,7 +321,7 @@ class ThreadPoolTest {
                   << std::endl;
         std::cout << "  Results correct: " << (correct ? "Yes" : "No") << std::endl;
 
-        assert(correct);
+        EXPECT_TRUE(correct);
 
         // Test with custom grain size
         std::fill(results.begin(), results.end(), 0);
@@ -338,7 +336,7 @@ class ThreadPoolTest {
             }
         }
 
-        assert(correct);
+        EXPECT_TRUE(correct);
         std::cout << "  Custom grain size test: " << (correct ? "Passed" : "Failed") << std::endl;
 
         std::cout << "  ✓ ParallelFor integration working correctly" << std::endl;
@@ -387,7 +385,7 @@ class ThreadPoolTest {
                   << std::endl;
         std::cout << "  Results correct: " << (correct ? "Yes" : "No") << std::endl;
 
-        assert(correct);
+        EXPECT_TRUE(correct);
 
         // Test with different function
         ParallelUtils::parallelTransform(input.data(), output.data(), size,
@@ -407,7 +405,7 @@ class ThreadPoolTest {
             }
         }
 
-        assert(correct);
+        EXPECT_TRUE(correct);
         std::cout << "  SQRT transform test: " << (correct ? "Passed" : "Failed") << std::endl;
 
         std::cout << "  ✓ SIMD-aware parallel transform working correctly" << std::endl;
@@ -439,7 +437,7 @@ class ThreadPoolTest {
         std::cout << "  Sum: " << sum << " (expected: " << expected << ")" << std::endl;
         std::cout << "  Results correct: " << (correct ? "Yes" : "No") << std::endl;
 
-        assert(correct);
+        EXPECT_TRUE(correct);
 
         // Test with different operation (product of first N natural numbers)
         const std::size_t smallSize = 10;
@@ -456,7 +454,7 @@ class ThreadPoolTest {
         std::cout << "  Product test: " << product << " (expected: " << expectedProduct << ")"
                   << std::endl;
 
-        assert(correct);
+        EXPECT_TRUE(correct);
         std::cout << "  ✓ Parallel reduce integration working correctly" << std::endl;
     }
 
@@ -501,7 +499,7 @@ class ThreadPoolTest {
         std::cout << "  Results match: " << (correct ? "Yes" : "No") << std::endl;
         std::cout << "  Results reasonable: " << (reasonable ? "Yes" : "No") << std::endl;
 
-        assert(correct);
+        EXPECT_TRUE(correct);
 
         // Test parallel sum as well
         double parallelSum = ParallelUtils::parallelSum(std::span<const double>(data));
@@ -509,7 +507,7 @@ class ThreadPoolTest {
         bool sumCorrect = std::abs(parallelSum - sequentialSum) < 1e-6;
 
         std::cout << "  Parallel sum test: " << (sumCorrect ? "Passed" : "Failed") << std::endl;
-        assert(sumCorrect);
+        EXPECT_TRUE(sumCorrect);
 
         // Test parallel variance
         double parallelVar = ParallelUtils::parallelVariance(std::span<const double>(data));
@@ -525,7 +523,7 @@ class ThreadPoolTest {
         bool varCorrect = std::abs(parallelVar - sequentialVar) < 1e-6;
         std::cout << "  Parallel variance test: " << (varCorrect ? "Passed" : "Failed")
                   << std::endl;
-        assert(varCorrect);
+        EXPECT_TRUE(varCorrect);
 
         std::cout << "  ✓ Parallel statistical operations working correctly" << std::endl;
     }
@@ -545,12 +543,12 @@ class ThreadPoolTest {
                   << std::endl;
 
         // Test that the calculation is reasonable
-        assert(optimalThreads > 0);
-        assert(optimalThreads <= logicalCores);
+        EXPECT_TRUE(optimalThreads > 0);
+        EXPECT_TRUE(optimalThreads <= logicalCores);
 
         if (features.topology.hyperthreading) {
             // For CPU-intensive tasks, should prefer physical cores
-            assert(optimalThreads <= physicalCores);
+            EXPECT_TRUE(optimalThreads <= physicalCores);
         }
 
         std::cout << "  ✓ Optimal thread count calculation working correctly" << std::endl;
@@ -596,7 +594,7 @@ class ThreadPoolTest {
         bool correct = std::abs(sequentialSum - parallelSum) < 1e-6;
         std::cout << "  Results match: " << (correct ? "Yes" : "No") << std::endl;
 
-        assert(correct);
+        EXPECT_TRUE(correct);
 
         std::cout << "  ✓ Performance scaling working correctly" << std::endl;
 
@@ -651,7 +649,7 @@ class ThreadPoolTest {
         std::cout << "  Expected speedup achieved: " << (largeSpeedup > 1.5 ? "Yes" : "No")
                   << std::endl;
 
-        assert(largeCorrect);
+        EXPECT_TRUE(largeCorrect);
 
         // For multi-core systems, we should see significant speedup with large datasets
         if (ThreadPool::getOptimalThreadCount() > 1) {
@@ -679,7 +677,7 @@ class ThreadPoolTest {
             });
 
             double mean = future.get();
-            assert(std::abs(mean - 3.0) < TOLERANCE);
+            EXPECT_TRUE(std::abs(mean - 3.0) < TOLERANCE);
             std::cout << "  Example 1 mean: " << mean << std::endl;
         }
 
@@ -709,7 +707,7 @@ class ThreadPoolTest {
                 }
             }
 
-            assert(correct);
+            EXPECT_TRUE(correct);
             std::cout << "  Example 2 SIMD transform: " << (correct ? "Passed" : "Failed")
                       << std::endl;
         }
@@ -728,7 +726,7 @@ class ThreadPoolTest {
             double expected = (1.0 + 1000.0) / 2.0;
             [[maybe_unused]] bool correct = std::abs(mean - expected) < TOLERANCE;
 
-            assert(correct);
+            EXPECT_TRUE(correct);
             std::cout << "  Example 3 parallel mean: " << mean << " (expected: " << expected << ")"
                       << std::endl;
         }
@@ -737,13 +735,17 @@ class ThreadPoolTest {
     }
 };
 
-int main() {
-    try {
-        ThreadPoolTest test;
-        test.runAllTests();
-        return 0;
-    } catch (const std::exception& e) {
-        std::cerr << "\n❌ Test failed: " << e.what() << std::endl;
-        return 1;
-    }
-}
+
+TEST(ThreadPoolIntegration, Level0Constants)       { ThreadPoolTest t; t.testLevel0ConstantsIntegration(); }
+TEST(ThreadPoolIntegration, CpuDetection)          { ThreadPoolTest t; t.testCpuDetectionIntegration(); }
+TEST(ThreadPoolIntegration, SimdAwareness)          { ThreadPoolTest t; t.testSIMDAwareness(); }
+TEST(ThreadPoolIntegration, SafetyIntegration)      { ThreadPoolTest t; t.testSafetyIntegration(); }
+TEST(ThreadPoolIntegration, ErrorHandling)          { ThreadPoolTest t; t.testErrorHandlingIntegration(); }
+TEST(ThreadPoolIntegration, BasicFunctionality)     { ThreadPoolTest t; t.testBasicThreadPoolFunctionality(); }
+TEST(ThreadPoolIntegration, ParallelFor)            { ThreadPoolTest t; t.testParallelForIntegration(); }
+TEST(ThreadPoolIntegration, ParallelTransformSIMD)  { ThreadPoolTest t; t.testParallelTransformSIMD(); }
+TEST(ThreadPoolIntegration, ParallelReduce)         { ThreadPoolTest t; t.testParallelReduceIntegration(); }
+TEST(ThreadPoolIntegration, ParallelStatOperation)  { ThreadPoolTest t; t.testParallelStatOperation(); }
+TEST(ThreadPoolIntegration, OptimalThreadCount)     { ThreadPoolTest t; t.testOptimalThreadCountCalculation(); }
+TEST(ThreadPoolIntegration, PerformanceScaling)     { ThreadPoolTest t; t.testPerformanceScaling(); }
+TEST(ThreadPoolIntegration, DocumentationExamples)  { ThreadPoolTest t; t.testDocumentationExamples(); }

--- a/tests/test_work_stealing_pool.cpp
+++ b/tests/test_work_stealing_pool.cpp
@@ -1,15 +1,10 @@
 /**
  * @file test_work_stealing_pool.cpp
- * @brief Comprehensive test suite for WorkStealingPool with Level 0-2 integration
- *
- * This test suite verifies that the WorkStealingPool has the same Level 0-2 integration
- * as the ThreadPool implementation, plus work-stealing specific functionality.
+ * @brief GTest suite for WorkStealingPool with Level 0-2 integration
  */
-
 #include "libstats/platform/work_stealing_pool.h"
 
 #include <atomic>
-#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <concepts>
@@ -21,247 +16,143 @@
 #include <span>
 #include <vector>
 
+#include <gtest/gtest.h>
+
 using namespace stats;
 
-// C++20 concept for testing
 template <typename T>
 concept Numeric = std::integral<T> || std::floating_point<T>;
 
-int main() {
-    std::cout << "=== WorkStealingPool Test with C++20 ===\n\n";
-    std::cout << "C++ Standard: " << __cplusplus << "\n\n";
+TEST(WorkStealingPool, BasicTaskSubmission) {
+    WorkStealingPool pool(4);
+    std::atomic<int> counter{0};
 
-    // Test 1: Basic task submission and execution
-    std::cout << "Test 1: Basic task submission\n";
-    {
-        WorkStealingPool pool(4);  // 4 worker threads
-        std::atomic<int> counter{0};
-
-        // Submit 10 simple tasks
-        for (int i = 0; i < 10; ++i) {
-            pool.submit([&counter, i]() {
-                counter.fetch_add(1);
-                std::cout << "  Task " << i << " executed\n";
-            });
-        }
-
-        pool.waitForAll();
-        assert(counter.load() == 10);
-        std::cout << "  ✓ All 10 tasks executed successfully\n\n";
+    for (int i = 0; i < 10; ++i) {
+        pool.submit([&counter, i]() {
+            counter.fetch_add(1);
+            std::cout << "  Task " << i << " executed\n";
+        });
     }
 
-    // Test 2: C++20 ranges with parallel computation
-    std::cout << "Test 2: C++20 ranges with work stealing\n";
-    {
-        WorkStealingPool pool(4);
+    pool.waitForAll();
+    EXPECT_EQ(counter.load(), 10);
+    std::cout << "  All 10 tasks executed successfully\n";
+}
 
-        // Create data using C++20 ranges
-        std::vector<int> data;
-        auto range = std::views::iota(0, 1000) | std::views::transform([](int i) { return i * 2; });
-        std::ranges::copy(range, std::back_inserter(data));
+TEST(WorkStealingPool, CppRangesWithWorkStealing) {
+    WorkStealingPool pool(4);
 
-        std::atomic<long long> sum{0};
+    std::vector<int> data;
+    auto range = std::views::iota(0, 1000) | std::views::transform([](int i) { return i * 2; });
+    std::ranges::copy(range, std::back_inserter(data));
 
-        // Process data in parallel chunks
-        const size_t chunkSize = 100;
-        for (size_t start = 0; start < data.size(); start += chunkSize) {
-            size_t end = std::min(start + chunkSize, data.size());
-
-            pool.submit([&data, &sum, start, end]() {
-                long long localSum = 0;
-                for (size_t i = start; i < end; ++i) {
-                    localSum += data[i];
-                }
-                sum.fetch_add(localSum);
-            });
-        }
-
-        pool.waitForAll();
-
-        // Verify result
-        long long expectedSum = 0;
-        for (auto value : data) {
-            expectedSum += value;
-        }
-
-        assert(sum.load() == expectedSum);
-        std::cout << "  ✓ Parallel sum: " << sum.load() << " (expected: " << expectedSum << ")\n\n";
+    std::atomic<long long> sum{0};
+    const size_t chunkSize = 100;
+    for (size_t start = 0; start < data.size(); start += chunkSize) {
+        size_t end = std::min(start + chunkSize, data.size());
+        pool.submit([&data, &sum, start, end]() {
+            long long local = 0;
+            for (size_t i = start; i < end; ++i)
+                local += data[i];
+            sum.fetch_add(local);
+        });
     }
 
-    // Test 3: ParallelFor with C++20 concepts
-    std::cout << "Test 3: ParallelFor with concepts\n";
-    {
-        WorkStealingPool pool(4);
+    pool.waitForAll();
 
-        // Template function using C++20 concepts
-        auto process_numeric = [&pool]<Numeric T>(std::vector<T>& vec, T multiplier) {
-            pool.parallelFor(0, vec.size(), [&vec, multiplier](size_t i) { vec[i] *= multiplier; });
-        };
+    long long expected = 0;
+    for (auto v : data) expected += v;
+    EXPECT_EQ(sum.load(), expected);
+    std::cout << "  Parallel sum: " << sum.load() << " (expected: " << expected << ")\n";
+}
 
-        std::vector<int> int_data(1000);
-        std::iota(int_data.begin(), int_data.end(), 1);
+TEST(WorkStealingPool, ParallelForWithConcepts) {
+    WorkStealingPool pool(4);
 
-        process_numeric(int_data, 3);
+    auto process_numeric = [&pool]<Numeric T>(std::vector<T>& vec, T multiplier) {
+        pool.parallelFor(0, vec.size(), [&vec, multiplier](size_t i) { vec[i] *= multiplier; });
+    };
 
-        // Verify first few elements
-        assert(int_data[0] == 3);       // 1 * 3
-        assert(int_data[1] == 6);       // 2 * 3
-        assert(int_data[999] == 3000);  // 1000 * 3
+    std::vector<int> int_data(1000);
+    std::iota(int_data.begin(), int_data.end(), 1);
+    process_numeric(int_data, 3);
 
-        std::cout << "  ✓ Concept-based parallelFor processed 1000 elements\n\n";
+    EXPECT_EQ(int_data[0], 3);
+    EXPECT_EQ(int_data[1], 6);
+    EXPECT_EQ(int_data[999], 3000);
+    std::cout << "  Concept-based parallelFor processed 1000 elements\n";
+}
+
+TEST(WorkStealingPool, PerformanceAndStatistics) {
+    unsigned int thread_count = std::max(2u, std::thread::hardware_concurrency());
+    WorkStealingPool pool(thread_count);
+    const int numTasks = 1000;
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < numTasks; ++i) {
+        pool.submit([i]() {
+            auto work = std::views::iota(0, (i % 10 + 1) * 100)
+                      | std::views::transform([](int x) { return x * x; })
+                      | std::views::take(50);
+            volatile long long s = 0;
+            for (auto v : work) s = s + v;
+        });
+    }
+    pool.waitForAll();
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto stats = pool.getStatistics();
+    std::cout << "  Execution: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()
+              << " ms, steals: " << stats.workSteals << "\n";
+
+    EXPECT_EQ(static_cast<int>(stats.tasksExecuted), numTasks);
+}
+
+TEST(WorkStealingPool, GlobalUtilities) {
+    std::atomic<int> counter{0};
+
+    std::vector<int> indices;
+    std::ranges::copy(std::views::iota(0, 50), std::back_inserter(indices));
+
+    for ([[maybe_unused]] auto i : indices) {
+        stats::workStealingSubmit([&counter]() { counter.fetch_add(1); });
     }
 
-    // Test 4: Work stealing statistics with performance measurement
-    std::cout << "Test 4: Performance and statistics\n";
-    {
-        // Ensure we have at least 1 thread (hardware_concurrency can return 0)
-        unsigned int thread_count = std::thread::hardware_concurrency();
-        if (thread_count == 0)
-            thread_count = 2;  // Default to 2 if detection fails
-        WorkStealingPool pool(thread_count);
-        const int numTasks = 1000;
+    stats::workStealingWaitForAll();
+    EXPECT_EQ(counter.load(), 50);
+    std::cout << "  Global utilities executed " << counter.load() << " tasks\n";
+}
 
-        auto start_time = std::chrono::high_resolution_clock::now();
+TEST(WorkStealingPool, Level0ConstantsIntegration) {
+    auto parallelThreshold      = arch::get_min_elements_for_parallel();
+    auto distributionThreshold  = arch::get_min_elements_for_distribution_parallel();
+    auto defaultGrainSize       = arch::get_default_grain_size();
+    auto simdBlockSize          = arch::get_optimal_simd_block_size();
+    auto memoryAlignment        = arch::get_optimal_alignment();
 
-        // Submit variable-work tasks to trigger stealing
-        for (int i = 0; i < numTasks; ++i) {
-            pool.submit([i]() {
-                // Variable work amounts using C++20 features
-                auto work_amount = std::views::iota(0, (i % 10 + 1) * 100) |
-                                   std::views::transform([](int x) { return x * x; }) |
-                                   std::views::take(50);
+    EXPECT_GT(parallelThreshold, 0u);
+    EXPECT_GT(distributionThreshold, 0u);
+    EXPECT_GT(defaultGrainSize, 0u);
+    EXPECT_GT(simdBlockSize, 0u);
+    EXPECT_GT(memoryAlignment, 0u);
 
-                volatile long long sum = 0;
-                for (auto value : work_amount) {
-                    sum = sum + value;
-                }
-            });
-        }
+    std::cout << "  Min parallel: " << parallelThreshold
+              << ", grain: " << defaultGrainSize
+              << ", alignment: " << memoryAlignment << " bytes\n";
+}
 
-        pool.waitForAll();
+TEST(WorkStealingPool, CPUDetectionIntegration) {
+    const auto& features    = arch::get_features();
+    auto optimalThreads     = WorkStealingPool::getOptimalThreadCount();
 
-        auto end_time = std::chrono::high_resolution_clock::now();
-        auto duration =
-            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+    EXPECT_GT(optimalThreads, 0u);
 
-        auto stats = pool.getStatistics();
-        std::cout << "  Execution time: " << duration.count() << " ms\n";
-        std::cout << "  Tasks executed: " << stats.tasksExecuted << "\n";
-        std::cout << "  Work steals: " << stats.workSteals << "\n";
-        std::cout << "  Steal success rate: " << (stats.stealSuccessRate * 100) << "%\n";
-        std::cout << "  Hardware threads: " << std::thread::hardware_concurrency() << "\n";
-
-        assert(stats.tasksExecuted == numTasks);
-        std::cout << "  ✓ All tasks completed with work stealing active\n\n";
+    if (features.topology.hyperthreading && features.topology.logical_cores > 0) {
+        EXPECT_LE(optimalThreads, features.topology.logical_cores);
     }
 
-    // Test 5: Global utilities with C++20 features
-    std::cout << "Test 5: Global utilities\n";
-    {
-        std::atomic<int> counter{0};
-
-        // Use C++20 ranges to generate task indices
-        std::vector<int> task_indices;
-        auto range = std::views::iota(0, 50);
-        std::ranges::copy(range, std::back_inserter(task_indices));
-
-        for ([[maybe_unused]] auto i : task_indices) {
-            stats::workStealingSubmit([&counter]() { counter.fetch_add(1); });
-        }
-
-        stats::workStealingWaitForAll();
-        assert(counter.load() == 50);
-        std::cout << "  ✓ Global utilities executed " << counter.load() << " tasks\n\n";
-    }
-
-    // Test 6: Level 0 Constants Integration
-    std::cout << "Test 6: Level 0 Constants Integration\n";
-    {
-        // Test that constants are properly used
-        auto parallelThreshold = arch::get_min_elements_for_parallel();
-        auto distributionThreshold = arch::get_min_elements_for_distribution_parallel();
-        auto defaultGrainSize = arch::get_default_grain_size();
-        auto simdBlockSize = arch::get_optimal_simd_block_size();
-        auto memoryAlignment = arch::get_optimal_alignment();
-
-        std::cout << "  Min parallel size: " << parallelThreshold << std::endl;
-        std::cout << "  Min distribution parallel size: " << distributionThreshold << std::endl;
-        std::cout << "  Default grain size: " << defaultGrainSize << std::endl;
-        std::cout << "  SIMD block size: " << simdBlockSize << std::endl;
-        std::cout << "  Memory alignment: " << memoryAlignment << " bytes" << std::endl;
-
-        // Verify constants are reasonable
-        assert(parallelThreshold > 0);
-        assert(distributionThreshold > 0);
-        assert(defaultGrainSize > 0);
-        assert(simdBlockSize > 0);
-        assert(memoryAlignment > 0);
-
-        std::cout << "  ✓ Constants integration working correctly\n\n";
-    }
-
-    // Test 7: CPU Detection Integration
-    std::cout << "Test 7: CPU Detection Integration\n";
-    {
-        const auto& features = arch::get_features();
-        auto physicalCores = features.topology.physical_cores;
-        auto logicalCores = features.topology.logical_cores;
-        auto l1CacheSize = features.l1_cache_size;
-        auto l2CacheSize = features.l2_cache_size;
-        auto l3CacheSize = features.l3_cache_size;
-        auto cacheLineSize = features.cache_line_size;
-        auto optimalThreads = WorkStealingPool::getOptimalThreadCount();
-
-        std::cout << "  Physical cores: " << physicalCores << std::endl;
-        std::cout << "  Logical cores: " << logicalCores << std::endl;
-        std::cout << "  L1 cache: " << (l1CacheSize > 0 ? l1CacheSize / 1024 : 0) << " KB"
-                  << std::endl;
-        std::cout << "  L2 cache: " << (l2CacheSize > 0 ? l2CacheSize / 1024 : 0) << " KB"
-                  << std::endl;
-        std::cout << "  L3 cache: " << (l3CacheSize > 0 ? l3CacheSize / 1024 / 1024 : 0) << " MB"
-                  << std::endl;
-        std::cout << "  Cache line size: " << cacheLineSize << " bytes" << std::endl;
-        std::cout << "  Optimal threads: " << optimalThreads << std::endl;
-        std::cout << "  Has hyperthreading: " << (features.topology.hyperthreading ? "Yes" : "No")
-                  << std::endl;
-
-        // Be lenient for CI/VM environments where CPU detection might not fully work
-        if (physicalCores == 0) {
-            std::cerr
-                << "  Warning: physicalCores could not be detected on this platform (CI runner?)"
-                << std::endl;
-        }
-        // physicalCores is size_t (unsigned): zero means undetectable (CI/VM), not invalid
-
-        if (logicalCores == 0) {
-            std::cerr
-                << "  Warning: logicalCores could not be detected on this platform (CI runner?)"
-                << std::endl;
-        }
-        // logicalCores is size_t (unsigned): zero means undetectable, not invalid
-
-        // Cache sizes might be 0 or unavailable on VMs/CI runners
-        // All are size_t (unsigned): always >= 0 by type; zero means undetectable
-
-        if (cacheLineSize == 0) {
-            std::cerr
-                << "  Warning: Cache line size could not be detected on this platform (CI runner?)"
-                << std::endl;
-        }
-        // cacheLineSize is size_t (unsigned): zero means undetectable, not invalid
-
-        // Optimal threads should always be at least 1
-        assert(optimalThreads > 0);
-
-        if (features.topology.hyperthreading) {
-            // Work stealing pools can use logical cores effectively
-            assert(optimalThreads <= logicalCores);
-        }
-
-        std::cout << "  ✓ CPU detection integration working correctly\n\n";
-    }
-
-    std::cout << "🎉 All WorkStealingPool tests passed with Level 0-2 integration!\n";
-
-    return 0;
+    std::cout << "  Physical: " << features.topology.physical_cores
+              << ", Logical: " << features.topology.logical_cores
+              << ", Optimal: " << optimalThreads << "\n";
 }


### PR DESCRIPTION
## Summary

Addresses issues #19, #20, #21, and #18 in order. Also fixes two pre-existing bugs surfaced by the test migration, and completes the distribution API standard across all 9 distributions.

## Commits

### test(quality): migrate 11 assert-based tests to GTest (closes #19)

All 11 standalone test files (`test_constants`, `test_simd_policy`, `test_thread_pool`, `test_work_stealing_pool`, `test_platform_optimizations`, `test_atomic_parameters`, `test_parallel_execution_integration`, `test_parallel_execution_comprehensive`, `test_error_handling_comprehensive`, `test_numerical_safety`, `test_benchmark`) converted from raw `assert()` + `main()` to GTest `TEST()` suites. CMakeLists updated to use `create_libstats_gtest()` for each.

The conversion revealed two pre-existing bugs that were masked by the old exit-code behaviour:

### fix: remove imprecise log-space lookup table; reject discrete equal bounds

- **`LogSpaceOps::logSumExp`**: The 1024-point lookup table for `log(1+exp(x))` over `[-50,0]` gave ~6e-5 interpolation error — insufficient for the 1e-9 tolerances required by log-space arithmetic tests. `logSumExpArray` (the true hot path) never used the table. Remove table, `initialize()` retained as no-op for API compat, `logSumExp` now uses `std::log1p(std::exp(diff))` directly.
- **`validateDiscreteParameters`**: Changed `a > b` to `a >= b` — degenerate single-point `[k,k]` ranges are now correctly rejected, consistent with the test expectation and with `UniformDistribution`.

### refactor: replace categorizeBatchSize() if/else ladder with table + lower_bound (closes #20)

41-branch if/else chain in `PerformanceHistory::categorizeBatchSize` replaced with a `static constexpr std::array<size_t, 41>` and `std::lower_bound`. Same bucket behaviour, all 41 boundaries visible as data, O(log 41) instead of O(41). 8/8 PerformanceHistoryTest tests confirm correctness.

### refactor: collapse 4x CCN-35 dispatch threshold functions into shared impl (closes #21)

The four `neon/avx/avx2/avx512_parallel_threshold` functions had identical 35-branch control structure varying only in their empirical data. Replace with:
- `ThresholdRow {pdf, log_pdf, cdf}` — data for one distribution × 3 ops
- `ArchTable` — data for all 8 distributions on one architecture
- Four `constexpr ArchTable` instances (kNeon, kAvx, kAvx2, kAvx512)
- Single `parallelThresholdFromTable(table, dist, op)` — control structure written once
- Four wrappers reduced to one-line delegation

### refactor(#18)+feat: extract parallelBatchFit helper; add to all 9 distributions

- **Issue #18**: `GaussianDistribution::parallelBatchFit` and `ExponentialDistribution::parallelBatchFit` were textually identical (PMD CPD confirmed). `Uniform`, `Discrete`, `Poisson`, and `Gamma` had a lighter copy with silent exception swallowing (`future.wait()` with no error propagation).
- **New header** `include/core/parallel_batch_fit.h`: `detail::batchFitParallel<DistT>(datasets, results)` — thread-pool submission, per-chunk error recording, serial fallback, and serial error wrapping in one place.
- All 6 existing implementations replaced with one-line delegation.
- **API completeness**: `ChiSquaredDistribution`, `StudentTDistribution`, and `BetaDistribution` were missing `parallelBatchFit` entirely, violating the 9-distribution standard API. Declarations added to each header (section 6) and implementations added to the corresponding `.cpp` files.

## Test results

- 23/23 correctness tests pass
- 11/11 converted GTest tests pass
- PerformanceHistory 8/8, PerformanceDispatcher 9/9

Conversation: https://app.warp.dev/conversation/cb2267ef-9348-48cc-92b1-492cc8a9ce4f

Co-Authored-By: Oz <oz-agent@warp.dev>