### PR TITLE
ci: bump Node.js 20 -> 24 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Install semantic-release and plugins
       run: |


### PR DESCRIPTION
One-line follow-up from the Node 24 deprecation audit.

The `release.yml` workflow explicitly pinned `node-version: '20'`. GitHub Actions runners switch to Node 24 by default on June 16, 2026; pinning to 20 would start generating deprecation warnings. Bumped to 24.

All semantic-release packages used here (`semantic-release`, `@semantic-release/*`, `conventional-changelog-conventionalcommits`) are compatible with Node 24.

Co-Authored-By: Oz <oz-agent@warp.dev>