### PR TITLE
docs: deprecate macOS Catalina / Ivy Bridge support in v1.5.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,14 @@ Asus TUF A16 primitive vector op speedups (v1.5.0 Phase 4): VectorExp 5.0x, Vect
 - Mac Mini M1 (61): Phase 3 validated ✅.
 - Asus TUF A16 (61): Phase 4 validated ✅.
 
+> **⚠️ Deprecation notice — Ivy Bridge / macOS Catalina:** v1.5.0 is the last version
+> validated on macOS 10.15 (Catalina) and Ivy Bridge hardware. macOS Catalina is
+> end-of-life; Homebrew will drop Catalina support in the upcoming macOS 27 release,
+> eliminating the toolchain maintenance path. A future v2.0.0 will set the minimum
+> macOS requirement to 13 (Ventura), consistent with libhmm. The Catalina-specific
+> CMake guards (`CROSS_PLATFORM` build type, `LIBSTATS_HAS_REQUIRES_EXPRESSIONS`)
+> will be removed at that point.
+
 ### SIMD Batch Operation Speedups (Ivy Bridge, AVX)
 v1.5.0 results (61/61 simd_verification ✅): PDF geomean 5.6x, LogPDF 6.0x, CDF 2.6x.
 Primitive ops: VectorExp 2.2x, VectorLog 1.3x, VectorErf 1.7x, VectorCos 11.0x.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,20 @@
   PDF 4.8x, LogPDF 5.1x, CDF 2.2x; VectorExp 5.0x, VectorLog 3.9x, VectorErf 1.3x, VectorCos 8.5x.
 - 39/39 correctness, 61/61 `simd_verification` — Mac Mini M1 NEON:
   PDF 5.9x, LogPDF 7.3x, CDF 3.1x; VectorExp 2.1x, VectorLog 1.8x, VectorErf 8.0x, VectorCos 3.0x.
+- 38/38 correctness (1 skipped), 61/61 `simd_verification` — Ivy Bridge AVX (macOS Catalina):
+  PDF 5.6x, LogPDF 6.0x, CDF 2.6x; VectorExp 2.2x, VectorLog 1.3x, VectorErf 1.7x, VectorCos 11.0x.
+
+### Deprecation Notices
+- **macOS Catalina (10.15) support is deprecated as of v1.5.0** and will be removed in
+  a future v2.0.0 release. v1.5.0 is the last version that will be validated on
+  macOS 10.15 / Ivy Bridge hardware. Rationale:
+  - macOS 10.15 is end-of-life; the upcoming macOS 27 release will cause Homebrew to
+    drop Catalina support entirely, eliminating the toolchain maintenance path.
+  - The Catalina-specific CMake guards (`CROSS_PLATFORM` build type, Homebrew LLVM
+    fallback detection, `LIBSTATS_HAS_REQUIRES_EXPRESSIONS` gating) add complexity
+    that is disproportionate to the remaining user base on hardware this old.
+  - This aligns with libhmm, which dropped macOS < 13/Ventura support in v4.0.
+  - **Minimum macOS from v2.0.0:** macOS 13 Ventura (Apple Clang 14+).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Tests are labelled: **no label** = correctness (parallel-safe); **timing** = spe
 - **CMake**: 3.20 or later
 - **Platform**: Windows, macOS, Linux (automatic detection and optimization)
 
+> **⚠️ macOS Catalina (10.15) deprecation:** v1.5.0 is the last release validated on
+> macOS 10.15 and Ivy Bridge hardware. A future v2.0.0 will require macOS 13 (Ventura)
+> or later, consistent with libhmm. See [CHANGELOG.md](CHANGELOG.md) for details.
+
 #### Common Build Configurations
 
 | Configuration | Command | Use Case |
@@ -313,15 +317,15 @@ See [`consumer_example/`](consumer_example/) for a complete `find_package` proje
 
 ## Current State
 
-The library is at **v1.4.0** on `main`.
+The library is at **v1.5.0 (in development)** on `main`. v1.4.0 was the last tagged release.
 
 **16 distributions across 6 families** (symmetric, positive-support, power-law, bounded, circular, discrete) — each with a complete interface:
 - PDF, log-PDF, CDF, quantile, sampling, MLE (`fit()`), and `parallelBatchFit()`
-- SIMD batch operations (SSE2/AVX/AVX2/AVX-512/NEON) with runtime dispatch
+- SIMD batch operations (SSE2/AVX/AVX2+FMA/AVX-512/NEON) with runtime dispatch
 - Profiling-derived architecture-aware parallel dispatch thresholds
 - Thread-safe with reader-writer locks and lock-free atomic fast paths
 
-**Validated on four architectures:** Intel Ivy Bridge (AVX), Intel Kaby Lake (AVX2), Apple Silicon M1 (NEON), AMD Zen 4 Asus TUF A16 (AVX-512/MSVC). 54/54 SIMD verification tests pass on all four machines.
+**Validated on four architectures:** Intel Ivy Bridge/AVX, Intel Kaby Lake/AVX2+FMA, Apple Silicon M1/NEON, AMD Zen 4/AVX-512. 61/61 SIMD verification tests pass on all four machines.
 
 For the full release history, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
Adds deprecation notices to CHANGELOG.md, AGENTS.md, and README.md stating that v1.5.0 is the last release validated on macOS 10.15 / Ivy Bridge hardware, and that v2.0.0 will set the minimum macOS requirement to 13 (Ventura), consistent with libhmm v4.0.

**Rationale:** macOS Catalina is truly EOL; the upcoming macOS 27 release will cause Homebrew to drop Catalina support entirely, eliminating the toolchain maintenance path. The Catalina-specific CMake guards (`CROSS_PLATFORM` build type, `LIBSTATS_HAS_REQUIRES_EXPRESSIONS` gating) add complexity disproportionate to the remaining user base on 2012-era hardware.

This is documentation-only — no code or build system changes. Phase 5 dispatch threshold recalibration is separate.

Co-Authored-By: Oz <oz-agent@warp.dev>