### PR TITLE
fix: v1.5.3 — bugfixes, deprecation sweep, VonMises pass, CI/docs hygiene

### DIFF
--- a/.github/workflows/avx512-compilation.yml
+++ b/.github/workflows/avx512-compilation.yml
@@ -65,7 +65,7 @@ jobs:
           -DLIBSTATS_HAS_AVX512 \
           -mavx512f -mavx512dq -mavx512bw -mavx512vl \
           -c src/simd_avx512.cpp \
-          -o avx512_test.o || echo "AVX-512 source compilation failed"
+          -o avx512_test.o || { echo "AVX-512 source compilation failed"; exit 1; }
 
         # Test compilation of dispatch logic with AVX-512 enabled
         echo "Testing simd_dispatch.cpp with AVX-512 enabled..."
@@ -75,7 +75,7 @@ jobs:
           -DLIBSTATS_HAS_AVX512 \
           -mavx512f -mavx512dq -mavx512bw -mavx512vl \
           -c src/simd_dispatch.cpp \
-          -o dispatch_avx512_test.o || echo "Dispatch compilation failed"
+          -o dispatch_avx512_test.o || { echo "Dispatch compilation failed"; exit 1; }
 
         echo "✅ Individual source file compilation tests completed"
 

--- a/.github/workflows/avx512-compilation.yml
+++ b/.github/workflows/avx512-compilation.yml
@@ -57,10 +57,12 @@ jobs:
       run: |
         echo "=== Compiling AVX-512 source files individually ==="
 
-        # Test compilation of AVX-512 source with forced flags
+        # Source files use #include "libstats/..." which resolves via the CMake-generated
+        # include shim at build/include_shim/ (created by the Configure step above).
+        # -I include alone cannot resolve the libstats/ prefix.
         echo "Testing simd_avx512.cpp compilation..."
         ${{ matrix.compiler.cxx }} \
-          -I include -I . \
+          -I build/include_shim \
           -std=c++20 \
           -DLIBSTATS_HAS_AVX512 \
           -mavx512f -mavx512dq -mavx512bw -mavx512vl \
@@ -70,7 +72,7 @@ jobs:
         # Test compilation of dispatch logic with AVX-512 enabled
         echo "Testing simd_dispatch.cpp with AVX-512 enabled..."
         ${{ matrix.compiler.cxx }} \
-          -I include -I . \
+          -I build/include_shim \
           -std=c++20 \
           -DLIBSTATS_HAS_AVX512 \
           -mavx512f -mavx512dq -mavx512bw -mavx512vl \

--- a/.github/workflows/avx512-compilation.yml
+++ b/.github/workflows/avx512-compilation.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - { name: gcc-12, cc: gcc-12, cxx: g++-12 }
-          - { name: clang-15, cc: clang-15, cxx: clang++-15 }
+          - { name: gcc-13, cc: gcc-13, cxx: g++-13 }
+          - { name: clang-17, cc: clang-17, cxx: clang++-17 }
         build_type: [Debug, Release]
 
     steps:
@@ -33,9 +33,7 @@ jobs:
         if [[ "${{ matrix.compiler.cc }}" == gcc* ]]; then
           sudo apt-get install -y ${{ matrix.compiler.cc }} ${{ matrix.compiler.cxx }}
         elif [[ "${{ matrix.compiler.cc }}" == clang* ]]; then
-          sudo apt-get install -y ${{ matrix.compiler.cc }}
-          # Install clang++-15 explicitly
-          sudo apt-get install -y clang++-15
+          sudo apt-get install -y ${{ matrix.compiler.cc }} ${{ matrix.compiler.cxx }}
         fi
 
     - name: Set Compiler Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,18 +181,18 @@ jobs:
     - name: Install tools
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang-format-15 clang-tidy-15 cppcheck
+        sudo apt-get install -y clang-format-17 clang-tidy-17 cppcheck
 
     - name: Check formatting
       run: |
-        find include src tests -name '*.h' -o -name '*.cpp' | xargs clang-format-15 --dry-run --Werror || true
+        find include src tests -name '*.h' -o -name '*.cpp' | xargs clang-format-17 --dry-run --Werror || true
         echo "Note: Format checking configured but not enforced yet"
 
     - name: Run clang-tidy
       run: |
         cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         # Only check our source files, exclude system headers
-        find src -name '*.cpp' | head -5 | xargs clang-tidy-15 -p build \
+        find src -name '*.cpp' | head -5 | xargs clang-tidy-17 -p build \
           --header-filter='.*/(include|src)/.*\.h$' \
           --system-headers=false \
           --warnings-as-errors="" || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,9 +387,9 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 # Strict compiler warnings as errors (for compatibility testing)
-cmake -DCMAKE_BUILD_TYPE=ClangStrict ..
-cmake -DCMAKE_BUILD_TYPE=GCCStrict ..
-cmake -DCMAKE_BUILD_TYPE=MSVCStrict ..
+cmake -DCMAKE_BUILD_TYPE=ClangStrict ..   # Note: deprecated in v1.5.3; removed in v2.0.0
+cmake -DCMAKE_BUILD_TYPE=GCCStrict ..    # Note: deprecated in v1.5.3; removed in v2.0.0
+cmake -DCMAKE_BUILD_TYPE=MSVCStrict ..   # Note: deprecated in v1.5.3; removed in v2.0.0
 ```
 
 ### Build System Features
@@ -424,7 +424,9 @@ cmake -DCMAKE_BUILD_TYPE=MSVCStrict ..
 
 For quick problem solving, diagnostics, and testing, you can compile directly without the CMake build system.
 
-### macOS with Homebrew LLVM (Recommended)
+### macOS with Homebrew LLVM (Legacy — system AppleClang preferred)
+
+> **Note:** Homebrew LLVM was required for C++20 on macOS Catalina. On Ventura+ (and the Kaby Lake/M1 machines in this ecosystem), system AppleClang is recommended for ABI safety. Homebrew LLVM build support is removed in v2.0.0. Use the system compiler for all new development.
 
 #### Quick Template for Ad Hoc Tests
 ```bash
@@ -575,7 +577,7 @@ Level 5: Complete Library Interface (libstats.h)
 
 ### Core Components
 
-#### Statistical Distributions (9 implemented)
+#### Statistical Distributions (16 across 6 families)
 1. **Gaussian** (Normal) - N(μ, σ²)
 2. **Exponential** - Exp(λ)
 3. **Uniform** - U(a, b)
@@ -585,6 +587,13 @@ Level 5: Complete Library Interface (libstats.h)
 7. **Chi-squared** - χ²(ν) — delegation wrapper over Gamma(α=ν/2, β=1/2)
 8. **Student's t** - t(ν) — SIMD log-space PDF/LogPDF and CDF via incomplete beta
 9. **Beta** - Beta(α, β) — two-log SIMD PDF/LogPDF and CDF via regularized incomplete beta
+10. **Log-Normal** - LogN(μ, σ) — log+exp pipeline
+11. **Pareto** - Pareto(xₘ, α) — log-only pipeline, power-law tail
+12. **Weibull** - W(k, λ) — log+exp pipeline, reliability engineering
+13. **Rayleigh** - R(σ) — x² pipeline, signal processing
+14. **Von Mises** - VM(μ, κ) — circular distribution, SIMD via vector_cos
+15. **Binomial** - B(n, p) — discrete, PMF via lgamma
+16. **Negative Binomial** - NB(r, p) — discrete, real-valued r, Newton–Raphson MLE
 
 Each provides: PDF/CDF/Quantiles, Statistical Moments, Parameter Estimation (MLE), Random Sampling, Statistical Validation, SIMD batch operations.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ endif()
 
 project(
     libstats
-    VERSION 1.5.2
+    VERSION 1.5.3
     LANGUAGES CXX)
 
 # Build examples by default only for top-level builds.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # libstats - Modern C++20 Statistical Distributions Library
 
-[![Version](https://img.shields.io/badge/version-v1.5.1-brightgreen.svg)](https://github.com/OldCrow/libstats/releases/tag/v1.5.1)
+---
+
+### 🚩 Final v1.x Release
+
+**v1.5.3 is the last release of the v1.x series.**
+v2.0.0 is in active development and will introduce breaking API changes:
+new namespace organisation, reduction of the deprecated API surface, platform
+baseline raised to macOS 13 Ventura / GCC 13 / AppleClang 15, and
+analysis utilities extracted to `stats::analysis`.
+
+If you are building new code against libstats, pin to **v1.5.3**.
+Migration notes will be published alongside the v2.0.0 release.
+
+---
+
+[![Version](https://img.shields.io/badge/version-v1.5.3-brightgreen.svg)](https://github.com/OldCrow/libstats/releases/tag/v1.5.3)
 [![CI](https://github.com/OldCrow/libstats/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libstats/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/OldCrow/libstats/graph/badge.svg)](https://codecov.io/gh/OldCrow/libstats)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)

--- a/cmake/libstats-config.cmake.in
+++ b/cmake/libstats-config.cmake.in
@@ -19,22 +19,28 @@ set(LIBSTATS_FOUND TRUE)
 set(LIBSTATS_VERSION "@PROJECT_VERSION@")
 set(LIBSTATS_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 
-# Provide different library options
-if(TARGET libstats::shared)
-    set(LIBSTATS_LIBRARIES libstats::shared)
-    set(LIBSTATS_SHARED_LIBRARIES libstats::shared)
+# Provide different library options.
+# CMake exports the actual target names with the namespace prefix applied:
+#   libstats_static  →  libstats::libstats_static
+#   libstats_shared  →  libstats::libstats_shared
+#   libstats_headers →  libstats::libstats_headers
+# The build-tree aliases libstats::static / libstats::shared / libstats::headers
+# are NOT exported (CMake cannot install alias targets).
+if(TARGET libstats::libstats_shared)
+    set(LIBSTATS_LIBRARIES libstats::libstats_shared)
+    set(LIBSTATS_SHARED_LIBRARIES libstats::libstats_shared)
 endif()
 
-if(TARGET libstats::static)
-    set(LIBSTATS_STATIC_LIBRARIES libstats::static)
+if(TARGET libstats::libstats_static)
+    set(LIBSTATS_STATIC_LIBRARIES libstats::libstats_static)
     # Default to static if no preference specified
     if(NOT DEFINED LIBSTATS_LIBRARIES)
-        set(LIBSTATS_LIBRARIES libstats::static)
+        set(LIBSTATS_LIBRARIES libstats::libstats_static)
     endif()
 endif()
 
-if(TARGET libstats::headers)
-    set(LIBSTATS_HEADER_LIBRARIES libstats::headers)
+if(TARGET libstats::libstats_headers)
+    set(LIBSTATS_HEADER_LIBRARIES libstats::libstats_headers)
 endif()
 
 # Report SIMD capabilities that were detected at build time

--- a/include/core/distribution_base.h
+++ b/include/core/distribution_base.h
@@ -120,35 +120,29 @@ class DistributionBase : public DistributionInterface, public ThreadSafeCacheMan
      * @note Base implementation uses parallel processing for large datasets; override for SIMD
      * optimization
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; removed in v2.0.0.")]]
     virtual std::vector<double> getBatchProbabilities(const std::vector<double>& x_values) const;
 
     /**
      * @brief Batch log probability density/mass function evaluation
-     * @param x_values Vector of values to evaluate
-     * @return Vector of log probability densities/masses
-     * @note Base implementation uses parallel processing for large datasets; override for SIMD
-     * optimization
+     * @deprecated Use getLogProbability(span, span, PerformanceHint) instead; removed in v2.0.0.
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; removed in v2.0.0.")]]
     virtual std::vector<double> getBatchLogProbabilities(const std::vector<double>& x_values) const;
 
     /**
      * @brief Batch cumulative distribution function evaluation
-     * @param x_values Vector of values to evaluate
-     * @return Vector of cumulative probabilities P(X <= x)
-     * @note Base implementation uses parallel processing for large datasets; override for SIMD
-     * optimization
+     * @deprecated Use getCumulativeProbability(span, span, PerformanceHint) instead; removed in v2.0.0.
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; removed in v2.0.0.")]]
     virtual std::vector<double> getBatchCumulativeProbabilities(
         const std::vector<double>& x_values) const;
 
     /**
      * @brief Batch quantile function evaluation
-     * @param p_values Vector of probability values in [0,1]
-     * @return Vector of quantile values
-     * @note Base implementation validates inputs and uses parallel processing; override for SIMD
-     * optimization
-     * @throws std::invalid_argument if any p_value not in [0,1]
+     * @deprecated Use getQuantile(span, span) instead; removed in v2.0.0.
      */
+    [[deprecated("Use getQuantile with span-based overloads instead; removed in v2.0.0.")]]
     virtual std::vector<double> getBatchQuantiles(const std::vector<double>& p_values) const;
 
     /**
@@ -173,10 +167,9 @@ class DistributionBase : public DistributionInterface, public ThreadSafeCacheMan
 
     /**
      * @brief Calculate Kullback-Leibler divergence from another distribution
-     * @param other Distribution to compare against
-     * @return KL divergence D(this||other)
-     * @note Base implementation uses numerical integration; override for efficiency
+     * @deprecated Never overridden and never called; removed in v2.0.0.
      */
+    [[deprecated("getKLDivergence has no overrides and no call sites; removed in v2.0.0.")]]
     virtual double getKLDivergence(const DistributionBase& other) const;
 
     // =============================================================================

--- a/include/core/distribution_memory.h
+++ b/include/core/distribution_memory.h
@@ -21,8 +21,10 @@ namespace stats {
 
 /**
  * @brief Memory pool for efficient allocation of temporary objects
+ * @deprecated MemoryPool and all types in this header are unused in src/ and tests/;
+ *   this header is removed in v2.0.0.
  */
-class MemoryPool {
+class [[deprecated("MemoryPool is unused and removed in v2.0.0; do not use in new code.")]] MemoryPool {
    private:
     static constexpr size_t POOL_SIZE = 1024 * 1024;  // 1MB pool
     static constexpr size_t ALIGNMENT = 64;           // Cache line alignment
@@ -185,11 +187,10 @@ class SIMDAllocator {
 
 /**
  * @brief Small vector optimization for temporary data
- * @tparam T Element type
- * @tparam N Number of elements in small buffer optimization
+ * @deprecated Removed in v2.0.0; use std::vector.
  */
 template <typename T, size_t N>
-class SmallVector {
+class [[deprecated("SmallVector is unused and removed in v2.0.0; use std::vector.")]] SmallVector {
    private:
     alignas(T) char small_buffer_[N * sizeof(T)];
     std::unique_ptr<T[]> heap_data_;
@@ -393,9 +394,10 @@ class SmallVector {
 
 /**
  * @brief Stack-based memory allocator for temporary computations
+ * @deprecated Removed in v2.0.0.
  */
 template <size_t StackSize = 4096>
-class StackAllocator {
+class [[deprecated("StackAllocator is unused and removed in v2.0.0.")]] StackAllocator {
    private:
     alignas(std::max_align_t) char stack_[StackSize];
     char* current_ = stack_;
@@ -433,9 +435,10 @@ class StackAllocator {
 
 /**
  * @brief SIMD-aligned vector type for efficient batch operations
+ * @deprecated Removed in v2.0.0; use std::vector with manual alignment if needed.
  */
 template <typename T>
-using simd_vector = std::vector<T, SIMDAllocator<T>>;
+using simd_vector [[deprecated("simd_vector is unused and removed in v2.0.0.")]] = std::vector<T, SIMDAllocator<T>>;
 
 /**
  * @brief Thread-local memory pool instance

--- a/include/core/performance_dispatcher.h
+++ b/include/core/performance_dispatcher.h
@@ -268,8 +268,11 @@ class PerformanceDispatcher {
 
         /**
          * @brief Refine thresholds based on measured system performance
-         * @param system System capabilities for fine-tuning
+         * @deprecated This method mutates per-distribution Thresholds fields that
+         *   selectStrategy() does not read; calling it has no effect on actual dispatch
+         *   behaviour. Removed in v2.0.0.
          */
+        [[deprecated("refineWithCapabilities mutates deprecated fields not read by selectStrategy(); removed in v2.0.0.")]]
         void refineWithCapabilities(const SystemCapabilities& system);
     };
 

--- a/include/distributions/beta.h
+++ b/include/distributions/beta.h
@@ -300,12 +300,15 @@ class BetaDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/binomial.h
+++ b/include/distributions/binomial.h
@@ -250,12 +250,15 @@ class BinomialDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/chi_squared.h
+++ b/include/distributions/chi_squared.h
@@ -409,18 +409,21 @@ class ChiSquaredDistribution : public DistributionBase {
     //==========================================================================
 
     /** @brief Explicit-strategy batch PDF — delegates to GammaDistribution. */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const {
         gamma_.getProbabilityWithStrategy(values, results, strategy);
     }
 
     /** @brief Explicit-strategy batch log-PDF — delegates to GammaDistribution. */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const {
         gamma_.getLogProbabilityWithStrategy(values, results, strategy);
     }
 
     /** @brief Explicit-strategy batch CDF — delegates to GammaDistribution. */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const {

--- a/include/distributions/discrete.h
+++ b/include/distributions/discrete.h
@@ -936,6 +936,7 @@ class DiscreteDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
@@ -952,6 +953,7 @@ class DiscreteDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
@@ -968,6 +970,7 @@ class DiscreteDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/exponential.h
+++ b/include/distributions/exponential.h
@@ -846,6 +846,7 @@ class ExponentialDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
@@ -862,6 +863,7 @@ class ExponentialDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
@@ -878,6 +880,7 @@ class ExponentialDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/gamma.h
+++ b/include/distributions/gamma.h
@@ -961,6 +961,7 @@ class GammaDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
@@ -977,6 +978,7 @@ class GammaDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
@@ -993,6 +995,7 @@ class GammaDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/gaussian.h
+++ b/include/distributions/gaussian.h
@@ -908,6 +908,7 @@ class GaussianDistribution : public DistributionBase {
      * @param strategy Explicit execution strategy to use
      * @throws std::invalid_argument if strategy is not supported
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
@@ -922,6 +923,7 @@ class GaussianDistribution : public DistributionBase {
      * @param strategy Explicit execution strategy to use
      * @throws std::invalid_argument if strategy is not supported
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
@@ -936,6 +938,7 @@ class GaussianDistribution : public DistributionBase {
      * @param strategy Explicit execution strategy to use
      * @throws std::invalid_argument if strategy is not supported
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/lognormal.h
+++ b/include/distributions/lognormal.h
@@ -299,12 +299,15 @@ class LogNormalDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/negative_binomial.h
+++ b/include/distributions/negative_binomial.h
@@ -253,12 +253,15 @@ class NegativeBinomialDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/pareto.h
+++ b/include/distributions/pareto.h
@@ -310,12 +310,15 @@ class ParetoDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/poisson.h
+++ b/include/distributions/poisson.h
@@ -897,6 +897,7 @@ class PoissonDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
@@ -913,6 +914,7 @@ class PoissonDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
@@ -929,6 +931,7 @@ class PoissonDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/rayleigh.h
+++ b/include/distributions/rayleigh.h
@@ -265,12 +265,15 @@ class RayleighDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/student_t.h
+++ b/include/distributions/student_t.h
@@ -309,12 +309,15 @@ class StudentTDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/uniform.h
+++ b/include/distributions/uniform.h
@@ -145,9 +145,12 @@ class UniformDistribution : public DistributionBase {
     /**
      * @brief Move constructor (DEFENSIVE THREAD SAFETY)
      * Implementation in .cpp: Thread-safe move with locking for legacy compatibility
-     * @warning NOT noexcept due to potential lock acquisition exceptions
+     * @warning NOT noexcept — lock acquisition can throw std::system_error.
+     *   std::vector reallocation will copy, not move, UniformDistribution elements.
+     *   This is intentional for correctness; noexcept move constructors require
+     *   atomic-only cache state (v2.0.0 prerequisite).
      */
-    UniformDistribution(UniformDistribution&& other) noexcept;
+    UniformDistribution(UniformDistribution&& other);
 
     /**
      * @brief Move assignment operator (DEFENSIVE THREAD SAFETY)
@@ -919,6 +922,7 @@ class UniformDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
@@ -935,6 +939,7 @@ class UniformDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
@@ -951,6 +956,7 @@ class UniformDistribution : public DistributionBase {
      *
      * @deprecated Consider migrating to auto-dispatch with hints for better portability
      */
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/distributions/von_mises.h
+++ b/include/distributions/von_mises.h
@@ -42,17 +42,13 @@ namespace stats {
  *   AppleClang / macOS libc++ always uses Tier 2.
  *
  * @par Batch operations and SIMD:
- * VectorOps currently has no vector_cos primitive, so the VECTORIZED strategy
- * uses a scalar loop — identical per-element cost to calling getLogProbability
- * individually, but with better cache behaviour for κ and μ (loop-invariant)
- * and crucially avoiding the per-element recomputation of logNormaliser_, which
- * requires log_bessel_i0(κ) (a Bessel function call). The PARALLEL strategy
- * provides genuine multi-core throughput and is the recommended choice for
- * large batches.
- *
- * If vector_cos is added to VectorOps in a future release, the VECTORIZED path
- * would reduce to a 3-step pipeline: scalar_add(−μ) → vector_cos → fused
- * scalar_multiply(κ) + scalar_add(−logNormaliser_).
+ * The VECTORIZED strategy uses `VectorOps::vector_cos` via the 4-step pipeline:
+ *   1. scalar_add(−μ)         — shift to zero-centred angle
+ *   2. vector_cos(results)    — SIMD cosine across all backends (AVX/AVX2/NEON/AVX-512)
+ *   3. scalar_multiply(κ)     — scale by concentration
+ *   4. scalar_add(−ln Z)      — subtract log-normaliser
+ * The PARALLEL strategy provides multi-core throughput for very large batches
+ * where the CDF path (512-step trapezoidal per element) dominates.
  *
  * @par MLE:
  * - μ̂ = atan2(Σsin(xᵢ), Σcos(xᵢ))  (one-pass circular mean)
@@ -286,6 +282,9 @@ class VonMisesDistribution : public DistributionBase {
     /** @brief Circular variance = 1 − I₁(κ)/I₀(κ). Same as getVariance(). */
     [[nodiscard]] double getCircularVariance() const noexcept;
 
+    /** @brief Median = μ (Von Mises is symmetric about μ). */
+    [[nodiscard]] double getMedian() const noexcept { return getMu(); }
+
     /** @brief Mode = μ (always at the mean direction). */
     [[nodiscard]] double getMode() const noexcept;
 
@@ -321,12 +320,15 @@ class VonMisesDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;
@@ -361,34 +363,25 @@ class VonMisesDistribution : public DistributionBase {
     //==========================================================================
 
     /**
-     * @brief Scalar-loop batch LogPDF / PDF.
+     * @brief SIMD-accelerated batch LogPDF / PDF via `VectorOps::vector_cos`.
      *
-     * VectorOps has no vector_cos, so the VECTORIZED path uses a scalar loop.
-     * Value vs per-element calls:
-     *   - logNormaliser_ = log(2π) + log_bessel_i0(κ) is cached — avoids one
-     *     Bessel function call per element.
-     *   - κ and μ are hoisted as loop-invariant scalars by the compiler.
-     *
-     * Hot path per element: κ·cos(x−μ) − logNormaliser_  (one cos call).
-     *
-     * When a vector_cos primitive is added to VectorOps in a future release,
-     * the pipeline becomes:
-     *   Step 1: results = x − μ                    [scalar_add(−mu_)]
-     *   Step 2: results = cos(results)              [vector_cos — future]
-     *   Step 3: results = κ·cos(x−μ) − logNorm     [scalar_multiply(kappa_) + scalar_add]
-     * Until then, PARALLEL is the recommended strategy for large batches.
+     * Pipeline: scalar_add(−μ) → vector_cos → scalar_multiply(κ) → scalar_add(−ln Z).
+     * logNormaliser_ is cached — avoids one Bessel call per element.
+     * κ and μ are loop-invariant scalars.
+     * These methods are "Unsafe" because they skip parameter validation;
+     * callers must hold the cache lock or guarantee parameter stability.
      */
-    void getLogProbabilityBatchImpl(const double* values, double* results, std::size_t count,
-                                    double cached_kappa, double cached_mu,
-                                    double cached_log_normaliser) const noexcept;
+    void getLogProbabilityBatchUnsafeImpl(const double* values, double* results, std::size_t count,
+                                          double cached_kappa, double cached_mu,
+                                          double cached_log_normaliser) const noexcept;
 
-    void getProbabilityBatchImpl(const double* values, double* results, std::size_t count,
-                                 double cached_kappa, double cached_mu,
-                                 double cached_log_normaliser) const noexcept;
+    void getProbabilityBatchUnsafeImpl(const double* values, double* results, std::size_t count,
+                                       double cached_kappa, double cached_mu,
+                                       double cached_log_normaliser) const noexcept;
 
-    /** @brief CDF batch — each element calls the 512-step trapezoidal CDF. */
-    void getCumulativeProbabilityBatchImpl(const double* values, double* results,
-                                           std::size_t count) const noexcept;
+    /** @brief CDF batch — each element calls the 512-step trapezoidal CDF. Unsafe: no validation. */
+    void getCumulativeProbabilityBatchUnsafeImpl(const double* values, double* results,
+                                                 std::size_t count) const noexcept;
 
     //==========================================================================
     // 19. PRIVATE COMPUTATIONAL METHODS

--- a/include/distributions/weibull.h
+++ b/include/distributions/weibull.h
@@ -301,12 +301,15 @@ class WeibullDistribution : public DistributionBase {
     // 14. EXPLICIT STRATEGY BATCH OPERATIONS
     //==========================================================================
 
+    [[deprecated("Use getProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                     detail::Strategy strategy) const;
 
+    [[deprecated("Use getLogProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getLogProbabilityWithStrategy(std::span<const double> values, std::span<double> results,
                                        detail::Strategy strategy) const;
 
+    [[deprecated("Use getCumulativeProbability(span, span, PerformanceHint) instead; explicit strategy methods removed in v2.0.0.")]]
     void getCumulativeProbabilityWithStrategy(std::span<const double> values,
                                               std::span<double> results,
                                               detail::Strategy strategy) const;

--- a/include/libstats.h
+++ b/include/libstats.h
@@ -169,11 +169,11 @@
     #include "distributions/binomial.h"
     #include "distributions/negative_binomial.h"
     #include "distributions/weibull.h"
-#endif  // LIBSTATS_FULL_INTERFACE
 
-// Main namespace for the statistical library
+// Type aliases — inside the guard because they reference types only defined
+// when LIBSTATS_FULL_INTERFACE is active.  Using them on incomplete types
+// compiles but produces confusing "incomplete type" errors on first use.
 namespace stats {
-// Type aliases for common usage
 using Gaussian = GaussianDistribution;
 using Normal = GaussianDistribution;
 using Exponential = ExponentialDistribution;
@@ -191,12 +191,18 @@ using Rayleigh = RayleighDistribution;
 using VonMises = VonMisesDistribution;
 using Binomial = BinomialDistribution;
 using NegativeBinomial = NegativeBinomialDistribution;
+}  // namespace stats
+#endif  // LIBSTATS_FULL_INTERFACE
 
-// Version information
+// Version constants and initialization — available in both lightweight and
+// full-interface modes; do not require complete distribution types.
+// TODO(v2.0.0): generate these from ${PROJECT_VERSION} via configure_file so
+// they cannot drift from the CMakeLists.txt version again.
+namespace stats {
 constexpr int LIBSTATS_VERSION_MAJOR = 1;
-constexpr int LIBSTATS_VERSION_MINOR = 2;
-constexpr int LIBSTATS_VERSION_PATCH = 0;
-constexpr const char* VERSION_STRING = "1.2.0";
+constexpr int LIBSTATS_VERSION_MINOR = 5;
+constexpr int LIBSTATS_VERSION_PATCH = 3;
+constexpr const char* VERSION_STRING = "1.5.3";
 
 /**
  * @brief Initialize performance systems to eliminate cold-start delays

--- a/src/uniform.cpp
+++ b/src/uniform.cpp
@@ -60,7 +60,7 @@ UniformDistribution& UniformDistribution::operator=(const UniformDistribution& o
     return *this;
 }
 
-UniformDistribution::UniformDistribution(UniformDistribution&& other) noexcept
+UniformDistribution::UniformDistribution(UniformDistribution&& other)
     : DistributionBase(std::move(other)) {
     std::unique_lock<std::shared_mutex> lock(other.cache_mutex_);
     a_ = other.a_;

--- a/src/von_mises.cpp
+++ b/src/von_mises.cpp
@@ -550,7 +550,7 @@ void VonMisesDistribution::getProbability(std::span<const double> values, std::s
             }
             const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
             lock.unlock();
-            d.getProbabilityBatchImpl(vals, res, count, k, mu, lnorm);
+            d.getProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
             if (vals.size() != res.size())
@@ -625,7 +625,7 @@ void VonMisesDistribution::getLogProbability(std::span<const double> values,
             }
             const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
             lock.unlock();
-            d.getLogProbabilityBatchImpl(vals, res, count, k, mu, lnorm);
+            d.getLogProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
             if (vals.size() != res.size())
@@ -689,7 +689,7 @@ void VonMisesDistribution::getCumulativeProbability(std::span<const double> valu
         detail::OperationType::CDF,
         [](const VonMisesDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const VonMisesDistribution& d, const double* vals, double* res, size_t count) {
-            d.getCumulativeProbabilityBatchImpl(vals, res, count);
+            d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
             if (vals.size() != res.size())
@@ -737,7 +737,7 @@ void VonMisesDistribution::getProbabilityWithStrategy(std::span<const double> va
             }
             const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
             lock.unlock();
-            d.getProbabilityBatchImpl(vals, res, count, k, mu, lnorm);
+            d.getProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
             const std::size_t count = vals.size();
@@ -799,7 +799,7 @@ void VonMisesDistribution::getLogProbabilityWithStrategy(std::span<const double>
             }
             const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
             lock.unlock();
-            d.getLogProbabilityBatchImpl(vals, res, count, k, mu, lnorm);
+            d.getLogProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
             const std::size_t count = vals.size();
@@ -850,7 +850,7 @@ void VonMisesDistribution::getCumulativeProbabilityWithStrategy(std::span<const 
         *this, values, results, strategy,
         [](const VonMisesDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const VonMisesDistribution& d, const double* vals, double* res, size_t count) {
-            d.getCumulativeProbabilityBatchImpl(vals, res, count);
+            d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
             const std::size_t count = vals.size();
@@ -933,7 +933,7 @@ std::istream& operator>>(std::istream& is, VonMisesDistribution& d) {
 // cache-validity check and lock acquisition on every element.
 //==============================================================================
 
-void VonMisesDistribution::getLogProbabilityBatchImpl(const double* values, double* results,
+void VonMisesDistribution::getLogProbabilityBatchUnsafeImpl(const double* values, double* results,
                                                       std::size_t count, double cached_kappa,
                                                       double cached_mu,
                                                       double cached_log_normaliser) const noexcept {
@@ -954,12 +954,12 @@ void VonMisesDistribution::getLogProbabilityBatchImpl(const double* values, doub
     }
 }
 
-void VonMisesDistribution::getProbabilityBatchImpl(const double* values, double* results,
+void VonMisesDistribution::getProbabilityBatchUnsafeImpl(const double* values, double* results,
                                                    std::size_t count, double cached_kappa,
                                                    double cached_mu,
                                                    double cached_log_normaliser) const noexcept {
     // Compute log-PDF then exponentiate
-    getLogProbabilityBatchImpl(values, results, count, cached_kappa, cached_mu,
+    getLogProbabilityBatchUnsafeImpl(values, results, count, cached_kappa, cached_mu,
                                cached_log_normaliser);
 
     // Step 4: results[i] = exp(results[i])
@@ -972,7 +972,7 @@ void VonMisesDistribution::getProbabilityBatchImpl(const double* values, double*
     }
 }
 
-void VonMisesDistribution::getCumulativeProbabilityBatchImpl(const double* values, double* results,
+void VonMisesDistribution::getCumulativeProbabilityBatchUnsafeImpl(const double* values, double* results,
                                                              std::size_t count) const noexcept {
     for (std::size_t i = 0; i < count; ++i)
         results[i] = getCumulativeProbability(values[i]);


### PR DESCRIPTION
## Summary

v1.5.3 is the final v1.x release. This PR covers all items from the pre-v2.0.0 precursor review, validated on all four machines (Kaby Lake AVX2+FMA, Ivy Bridge AVX, Mac Mini M1 NEON, Asus TUF A16 AVX-512).

## Bug fixes

- **BF-1**: Remove `noexcept` from `UniformDistribution` move constructor — the specifier directly contradicted the `@warning NOT noexcept` comment; a throwing mutex acquisition would have called `std::terminate`
- **BF-2**: Fix version constants frozen at `1.2.0` → `1.5.3`; bump CMakeLists `project(VERSION)` to match
- **BF-3**: Move type aliases (`Gaussian`, `Normal`, …) inside `LIBSTATS_FULL_INTERFACE` guard — aliases on incomplete types produced confusing errors on first use
- **BF-4**: Fix `libstats-config.cmake.in` exported target names (`libstats::static` → `libstats::libstats_static`) — `find_package(libstats)` compat variables were never populated

## Deprecation sweep

Adds `[[deprecated("...")]]` compiler-warning attributes to every API element scheduled for removal in v2.0.0:
- All 48 `*WithStrategy` batch methods (16 distributions × 3)
- `DistributionBase::getBatchProbabilities`, `getBatchLogProbabilities`, `getBatchCumulativeProbabilities`, `getBatchQuantiles`
- `DistributionBase::getKLDivergence`
- `MemoryPool`, `SmallVector`, `StackAllocator`, `simd_vector` (entire `distribution_memory.h`)
- `PerformanceDispatcher::Thresholds::refineWithCapabilities` (mutates fields `selectStrategy()` never reads)

## VonMises complete pass

- Add `getMedian()` returning `getMu()` — the distribution is symmetric; this method was absent from the core contract
- Replace stale "VectorOps has no `vector_cos`" comments with accurate description of the 4-step SIMD pipeline (`vector_cos` has been present since v1.4.0)
- Rename `*BatchImpl` → `*BatchUnsafeImpl` throughout header and `.cpp` to match naming convention used by all other distributions

## CI & documentation

- `avx512-compilation.yml`: fix swallowed failures (`|| echo` → `|| { …; exit 1; }`)
- `ci.yml` lint job: `clang-format-15`/`clang-tidy-15` → `17`
- `AGENTS.md`: distribution count corrected (9 → 16), `ClangStrict`/`GCCStrict`/`MSVCStrict` annotated as deprecated in v1.5.3, Homebrew LLVM section demoted from 'Recommended' to 'Legacy'
- `README.md`: prominent final-v1.x release banner added; version badge updated to v1.5.3

## Validation

| Machine | SIMD | Correctness |
|---|---|---|
| Kaby Lake (2017 MBP) | AVX2+FMA | 39/39 ✅ |
| Ivy Bridge (2012 MBP) | AVX | 38/38 ✅ |
| Mac Mini M1 | NEON | 39/39 ✅ |
| Asus TUF A16 (Windows) | AVX-512 | 39/39 ✅ |

---
Conversation: https://app.warp.dev/conversation/909ded9a-5776-4cb7-b3c9-f6ffa8119ecb

Co-Authored-By: Oz <oz-agent@warp.dev>
