### PR TITLE
Fix audit findings L1, L2, L6: benchmark flake, SIMD ODR hazard, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ See [`consumer_example/`](consumer_example/) for a complete `find_package` proje
 
 ## Current State
 
-v2.0.2 is released. v1.5.3 was the final v1.x release.
+v2.0.3 is released. v1.5.3 was the final v1.x release.
 
 **19 distributions across 7 families** (symmetric, positive-support, power-law, bounded, circular, discrete, real-line) — each with a complete interface:
 - PDF, log-PDF, CDF, quantile, sampling, MLE (`fit()`), and `parallelBatchFit()`

--- a/src/simd_avx.cpp
+++ b/src/simd_avx.cpp
@@ -1,4 +1,3 @@
-#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
 // AVX-specific SIMD implementations
 // This file is compiled ONLY with AVX flags to ensure safety
 //

--- a/src/simd_avx2.cpp
+++ b/src/simd_avx2.cpp
@@ -1,4 +1,3 @@
-#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
 // AVX2-specific SIMD implementations
 // This file is compiled ONLY with AVX2 flags to ensure safety
 

--- a/src/simd_avx512.cpp
+++ b/src/simd_avx512.cpp
@@ -1,4 +1,3 @@
-#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
 // AVX-512-specific SIMD implementations
 // This file is compiled ONLY with AVX-512 flags and includes runtime safety checks
 

--- a/src/simd_fallback.cpp
+++ b/src/simd_fallback.cpp
@@ -1,4 +1,3 @@
-#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
 // Scalar fallback implementations - no SIMD instructions
 // These implementations work on any CPU and serve as the baseline
 

--- a/src/simd_neon.cpp
+++ b/src/simd_neon.cpp
@@ -1,4 +1,3 @@
-#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
 // ARM NEON-specific SIMD implementations
 // This file is compiled ONLY with NEON flags to ensure safety
 

--- a/src/simd_sse2.cpp
+++ b/src/simd_sse2.cpp
@@ -1,9 +1,9 @@
-#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
 // SSE2-specific SIMD implementations
 // This file is compiled ONLY with SSE2 flags to ensure safety
 
 #include "libstats/common/cpu_detection_fwd.h"       // Use lightweight forward declarations
 #include "libstats/common/platform_constants_fwd.h"  // Use lightweight forward declarations
+#include "libstats/common/simd_implementation_common.h"  // VectorOps class + cpu_detection_fwd + platform_constants_fwd
 #include "libstats/core/math_constants.h"
 #include "libstats/core/statistical_constants.h"
 #include "libstats/platform/simd.h"

--- a/tests/test_benchmark.cpp
+++ b/tests/test_benchmark.cpp
@@ -190,7 +190,8 @@ void test_benchmark_class() {
         EXPECT_TRUE(results.size() == 1);
         EXPECT_TRUE(results[0].name == "simple_add");
         EXPECT_TRUE(results[0].stats.samples > 0);
-        EXPECT_TRUE(results[0].stats.mean > 0.0);
+        EXPECT_TRUE(results[0].stats.mean >=
+                    0.0);  // >= 0: mean=0 on fast machines where op is below timer resolution
 
         std::cout << "   ✓ Basic benchmark functionality passed\n";
     }


### PR DESCRIPTION
## Summary

Addresses findings L1, L2, and L6 from the 2026-07-04 audit. No API changes. 46/46 tests pass (was 45/46).

## L1 — `test_benchmark` brittle assertion

`tests/test_benchmark.cpp:193`: `EXPECT_TRUE(results[0].stats.mean > 0.0)` asserts that a `simple_add` benchmark measures a positive time. On fast machines the operation falls below timer resolution and measures exactly `0.0`, failing the suite. Changed to `>= 0.0`. This was the sole cause of the 45/46 result.

## L2 — ODR/COMDAT hazard in per-ISA SIMD TUs

All six per-ISA SIMD source files (`simd_avx512.cpp`, `simd_avx2.cpp`, `simd_avx.cpp`, `simd_sse2.cpp`, `simd_neon.cpp`, `simd_fallback.cpp`) opened with:
```cpp
#include "libstats/common/distribution_impl_common.h"  // SIMD + parallel (AQ-7)
```
That header pulls in `thread_pool.h`, `work_stealing_pool.h`, and `parallel_execution.h` — headers full of `inline` functions and templates — into TUs compiled with ISA-specific flags (`-mavx512f`, `-mavx2`, etc.). Any `inline` symbol emitted as a COMDAT in an ISA-specific TU could be the copy the linker keeps, giving non-dispatched code ISA-contaminated codegen that the runtime dispatch guards cannot prevent (SIGILL on non-supporting CPUs).

**Fix:** remove the include from all six per-ISA TUs. They only need `simd_implementation_common.h` (already present in five of the six) for `VectorOps` declarations, CPU-detection forwarders, and math constants. `simd_sse2.cpp` previously relied on `distribution_impl_common.h` for `simd.h`; `simd_implementation_common.h` is added there as a direct replacement.

`simd_dispatch.cpp` and `simd_policy.cpp` are not per-ISA kernel TUs and are left unchanged.

## L6 — Docs/hygiene

- `README.md:330`: "v2.0.2 is released" → "v2.0.3 is released"
- Deleted empty leftover directories: `backups/phase1_20250829_233815/` and `backups/phase1_20250830_142545/`
