### PR TITLE
refactor: unify DCL snapshot pattern across all 19 distributions (withCacheSnapshot)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides project-scoped guidance to AI agents and contributors working
 
 libstats is a **design and teaching library**: a demonstration of how to build statistical software correctly in modern C++20, with genuine SIMD and parallel performance. Zero external dependencies.
 
-**Current Status**: v2.0.3 on `main` — 46/46 correctness + 22/22 timing tests pass on
+**Current Status**: v2.0.4 on `main` — 46/46 correctness + 22/22 timing tests pass on
 Mac Mini M1 NEON; Kaby Lake AVX2+FMA and Asus TUF A16 AVX-512 validated via CI.
 v1.5.3 is the final v1.x release.
 
@@ -91,13 +91,13 @@ Platform routing rules (OS/toolchain selection — SIMD tier is determined autom
 
 ### Current Validation Matrix
 
-**v2.0.1 — current release (three machines)**
+**v2.0.4 — current release (three machines)**
 
 | Machine | SIMD | Correctness | Timing | Notes |
 |---|---|---|---|---|
-| Mac Mini M1 | NEON | 46/46 ✅ | 22/22 ✅ | Validated 2026-07-02 |
-| Kaby Lake (2017 MBP) | AVX2+FMA | 46/46 ✅ | — | CI validated; local timing re-run pending |
-| Asus TUF A16 (Windows) | AVX-512 | 46/46 ✅ | — | CI validated; local timing re-run pending |
+| Mac Mini M1 | NEON | 46/46 ✅ | 22/22 ✅ | Validated 2026-07-05 |
+| Kaby Lake (2017 MBP) | AVX2+FMA | 46/46 ✅ | — | CI validated |
+| Asus TUF A16 (Windows) | AVX-512 | 46/46 ✅ | — | CI validated |
 
 **v2.0.0 — validation target (three machines)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.0.4] - 2026-07-05
+
+### Refactoring
+
+- **Unified DCL snapshot pattern (`withCacheSnapshot`)**: Extracted the
+  double-checked locking + cache snapshot protocol used in every distribution
+  into a single `ThreadSafeCacheManager::withCacheSnapshot(SnapshotFn&&)` helper
+  (`include/core/distribution_cache.h`). All Pattern A (scalar methods) and
+  Pattern B (batch lambda) DCL blocks across 17 distribution source files replaced
+  with the unified helper. ~200 occurrences eliminated; no API or behavioural
+  change. 69/69 tests pass.
+
 ## [2.0.3] - 2026-07-04
 
 ### Performance

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 project(
     libstats
-    VERSION 2.0.3
+    VERSION 2.0.4
     LANGUAGES CXX)
 
 # v2.x compiler baseline. Fail early with actionable messages.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ---
 
-### v2.0.3 released
+### v2.0.4 released
 
-**v2.0.3 is the current release.** v1.5.3 was the final v1.x release.
+**v2.0.4 is the current release.** v1.5.3 was the final v1.x release.
 See [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md) for breaking changes and upgrade instructions.
 
 ---
 
-[![Version](https://img.shields.io/badge/version-v2.0.3-brightgreen.svg)](https://github.com/OldCrow/libstats/releases/tag/v2.0.3)
+[![Version](https://img.shields.io/badge/version-v2.0.4-brightgreen.svg)](https://github.com/OldCrow/libstats/releases/tag/v2.0.4)
 [![CI](https://github.com/OldCrow/libstats/actions/workflows/ci.yml/badge.svg)](https://github.com/OldCrow/libstats/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/OldCrow/libstats/graph/badge.svg)](https://codecov.io/gh/OldCrow/libstats)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
@@ -327,7 +327,7 @@ See [`consumer_example/`](consumer_example/) for a complete `find_package` proje
 
 ## Current State
 
-v2.0.3 is released. v1.5.3 was the final v1.x release.
+v2.0.4 is released. v1.5.3 was the final v1.x release.
 
 **19 distributions across 7 families** (symmetric, positive-support, power-law, bounded, circular, discrete, real-line) — each with a complete interface:
 - PDF, log-PDF, CDF, quantile, sampling, MLE (`fit()`), and `parallelBatchFit()`

--- a/include/core/distribution_cache.h
+++ b/include/core/distribution_cache.h
@@ -75,6 +75,45 @@ class ThreadSafeCacheManager {
      */
     template <typename Func>
     auto getCachedValue(Func&& accessor) const -> decltype(accessor());
+
+    /**
+     * @brief Acquire the correct lock, ensure the cache is valid, then call
+     *        @p snapFn to copy cached members into the caller's local variables.
+     *
+     * Encapsulates the double-checked locking pattern repeated in the
+     * VECTORIZED / PARALLEL / WORK_STEALING batch lambdas of every distribution:
+     * @code
+     *   // Before
+     *   double a, b;
+     *   { shared_lock ...; if (!valid) { unlock; unique_lock...; if (!valid) update; a=a_; b=b_; }
+     * else { a=a_; b=b_; } }
+     *   // After
+     *   double a, b;
+     *   dist.withCacheSnapshot([&]{ a = dist.a_; b = dist.b_; });
+     * @endcode
+     *
+     * The snapshot lambda is called while an appropriate lock is held —
+     * shared_lock when the cache was already valid, unique_lock otherwise —
+     * so there is no TOCTOU gap between the validity check and the reads.
+     *
+     * @tparam SnapshotFn  Callable void() that assigns from this object's
+     *                     mutable cached members into caller-owned variables.
+     */
+    template <typename SnapshotFn>
+    void withCacheSnapshot(SnapshotFn&& snapFn) const {
+        {
+            std::shared_lock<std::shared_mutex> lock(cache_mutex_);
+            if (cache_valid_) {
+                std::forward<SnapshotFn>(snapFn)();
+                return;
+            }
+        }  // release shared_lock before acquiring exclusive
+        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
+        if (!cache_valid_) {
+            updateCacheUnsafe();
+        }
+        std::forward<SnapshotFn>(snapFn)();
+    }
 };
 
 // =============================================================================

--- a/src/beta.cpp
+++ b/src/beta.cpp
@@ -544,24 +544,12 @@ void BetaDistribution::getProbability(std::span<const double> values, std::span<
         *this, values, results, hint, detail::OperationType::PDF,
         [](const BetaDistribution& dist, double value) { return dist.getProbability(value); },
         [](const BetaDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double lnc = dist.logNormConst_;
-                const double am1 = dist.alphaMinus1_;
-                const double bm1 = dist.betaMinus1_;
-                dist.getProbabilityBatchUnsafeImpl(vals, res, count, lnc, am1, bm1);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double lnc = dist.logNormConst_;
-            const double am1 = dist.alphaMinus1_;
-            const double bm1 = dist.betaMinus1_;
-            lock.unlock();
+            double lnc, am1, bm1;
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                am1 = dist.alphaMinus1_;
+                bm1 = dist.betaMinus1_;
+            });
             dist.getProbabilityBatchUnsafeImpl(vals, res, count, lnc, am1, bm1);
         },
         [](const BetaDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -571,24 +559,11 @@ void BetaDistribution::getProbability(std::span<const double> values, std::span<
             if (count == 0)
                 return;
             double lnc, am1, bm1;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                } else {
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                }
-            }
-            // Chunk the batch so each parallel task uses the SIMD pipeline
-            // (vector_log / vector_exp) instead of per-element scalar math.
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                am1 = dist.alphaMinus1_;
+                bm1 = dist.betaMinus1_;
+            });
             constexpr std::size_t CHUNK = 1024;
             if (arch::should_use_parallel(count)) {
                 const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
@@ -610,22 +585,11 @@ void BetaDistribution::getProbability(std::span<const double> values, std::span<
             if (count == 0)
                 return;
             double lnc, am1, bm1;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                } else {
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                am1 = dist.alphaMinus1_;
+                bm1 = dist.betaMinus1_;
+            });
             constexpr std::size_t CHUNK = 1024;
             const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
             pool.parallelFor(std::size_t{0}, num_chunks, [&](std::size_t ci) {
@@ -644,24 +608,12 @@ void BetaDistribution::getLogProbability(std::span<const double> values, std::sp
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const BetaDistribution& dist, double value) { return dist.getLogProbability(value); },
         [](const BetaDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double lnc = dist.logNormConst_;
-                const double am1 = dist.alphaMinus1_;
-                const double bm1 = dist.betaMinus1_;
-                dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, lnc, am1, bm1);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double lnc = dist.logNormConst_;
-            const double am1 = dist.alphaMinus1_;
-            const double bm1 = dist.betaMinus1_;
-            lock.unlock();
+            double lnc, am1, bm1;
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                am1 = dist.alphaMinus1_;
+                bm1 = dist.betaMinus1_;
+            });
             dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, lnc, am1, bm1);
         },
         [](const BetaDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -671,24 +623,11 @@ void BetaDistribution::getLogProbability(std::span<const double> values, std::sp
             if (count == 0)
                 return;
             double lnc, am1, bm1;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                } else {
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                }
-            }
-            // Chunk the batch so each parallel task uses the SIMD pipeline
-            // (vector_log) instead of per-element scalar math.
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                am1 = dist.alphaMinus1_;
+                bm1 = dist.betaMinus1_;
+            });
             constexpr std::size_t CHUNK = 1024;
             if (arch::should_use_parallel(count)) {
                 const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
@@ -711,22 +650,11 @@ void BetaDistribution::getLogProbability(std::span<const double> values, std::sp
             if (count == 0)
                 return;
             double lnc, am1, bm1;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                } else {
-                    lnc = dist.logNormConst_;
-                    am1 = dist.alphaMinus1_;
-                    bm1 = dist.betaMinus1_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                am1 = dist.alphaMinus1_;
+                bm1 = dist.betaMinus1_;
+            });
             constexpr std::size_t CHUNK = 1024;
             const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
             pool.parallelFor(std::size_t{0}, num_chunks, [&](std::size_t ci) {

--- a/src/binomial.cpp
+++ b/src/binomial.cpp
@@ -504,22 +504,11 @@ double BinomialDistribution::getMode() const {
 double BinomialDistribution::getEntropy() const {
     int n;
     double p, lnf;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            n = n_;
-            p = p_;
-            lnf = logNFact_;  // snapshot under unique_lock
-        } else {
-            n = n_;
-            p = p_;
-            lnf = logNFact_;  // snapshot under shared_lock
-        }
-    }
+    withCacheSnapshot([&] {
+        n = n_;
+        p = p_;
+        lnf = logNFact_;
+    });
 
     // Entropy is returned in nats (natural units; std::log = log base e).
     //

--- a/src/binomial.cpp
+++ b/src/binomial.cpp
@@ -255,26 +255,19 @@ double BinomialDistribution::getProbability(double x) const {
     if (p_ == detail::ONE)
         return (k == n_) ? detail::ONE : detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int sn = n_;
-        const double slnf = logNFact_, slp = logP_, sl1mp = log1mP_;
-        const double lc = (k > sn) ? detail::NEGATIVE_INFINITY
-                                   : slnf - std::lgamma(static_cast<double>(k + 1)) -
-                                         std::lgamma(static_cast<double>(sn - k + 1));
-        const double lp_val =
-            lc + static_cast<double>(k) * slp + static_cast<double>(sn - k) * sl1mp;
-        return std::clamp(std::exp(lp_val), detail::ZERO_DOUBLE, detail::ONE);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    const double lp =
-        logBinomCoeff(k) + static_cast<double>(k) * logP_ + static_cast<double>(n_ - k) * log1mP_;
-    return std::clamp(std::exp(lp), detail::ZERO_DOUBLE, detail::ONE);
+    int sn;
+    double slnf, slp, sl1mp;
+    withCacheSnapshot([&] {
+        sn = n_;
+        slnf = logNFact_;
+        slp = logP_;
+        sl1mp = log1mP_;
+    });
+    const double lc = (k > sn) ? detail::NEGATIVE_INFINITY
+                               : slnf - std::lgamma(static_cast<double>(k + 1)) -
+                                     std::lgamma(static_cast<double>(sn - k + 1));
+    const double lp_val = lc + static_cast<double>(k) * slp + static_cast<double>(sn - k) * sl1mp;
+    return std::clamp(std::exp(lp_val), detail::ZERO_DOUBLE, detail::ONE);
 }
 
 double BinomialDistribution::getLogProbability(double x) const {
@@ -290,23 +283,18 @@ double BinomialDistribution::getLogProbability(double x) const {
     if (p_ == detail::ONE)
         return (k == n_) ? detail::ZERO_DOUBLE : detail::NEGATIVE_INFINITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int sn = n_;
-        const double slnf = logNFact_, slp = logP_, sl1mp = log1mP_;
-        const double lc = (k > sn) ? detail::NEGATIVE_INFINITY
-                                   : slnf - std::lgamma(static_cast<double>(k + 1)) -
-                                         std::lgamma(static_cast<double>(sn - k + 1));
-        return lc + static_cast<double>(k) * slp + static_cast<double>(sn - k) * sl1mp;
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    return logBinomCoeff(k) + static_cast<double>(k) * logP_ +
-           static_cast<double>(n_ - k) * log1mP_;
+    int sn;
+    double slnf, slp, sl1mp;
+    withCacheSnapshot([&] {
+        sn = n_;
+        slnf = logNFact_;
+        slp = logP_;
+        sl1mp = log1mP_;
+    });
+    const double lc = (k > sn) ? detail::NEGATIVE_INFINITY
+                               : slnf - std::lgamma(static_cast<double>(k + 1)) -
+                                     std::lgamma(static_cast<double>(sn - k + 1));
+    return lc + static_cast<double>(k) * slp + static_cast<double>(sn - k) * sl1mp;
 }
 
 double BinomialDistribution::getCumulativeProbability(double x) const {
@@ -322,30 +310,17 @@ double BinomialDistribution::getCumulativeProbability(double x) const {
     if (k >= n_)
         return detail::ONE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int sn = n_;
-        const double sp = p_;
-        if (sp == detail::ZERO_DOUBLE)
-            return detail::ONE;  // all mass at k=0
-        if (sp == detail::ONE)
-            return detail::ZERO_DOUBLE;  // all mass at k=n
-        return detail::beta_i(detail::ONE - sp, static_cast<double>(sn - k),
-                              static_cast<double>(k + 1));
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    if (p_ == detail::ZERO_DOUBLE)
-        return detail::ONE;  // all mass at k=0
-    if (p_ == detail::ONE)
-        return detail::ZERO_DOUBLE;  // all mass at k=n
-
-    // CDF(k; n, p) = I_{1-p}(n-k, k+1)  — regularized incomplete beta
-    return detail::beta_i(detail::ONE - p_, static_cast<double>(n_ - k),
+    int sn;
+    double sp;
+    withCacheSnapshot([&] {
+        sn = n_;
+        sp = p_;
+    });
+    if (sp == detail::ZERO_DOUBLE)
+        return detail::ONE;
+    if (sp == detail::ONE)
+        return detail::ZERO_DOUBLE;
+    return detail::beta_i(detail::ONE - sp, static_cast<double>(sn - k),
                           static_cast<double>(k + 1));
 }
 
@@ -555,22 +530,14 @@ void BinomialDistribution::getProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::PDF,
         [](const BinomialDistribution& d, double x) { return d.getProbability(x); },
         [](const BinomialDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const int n = d.n_;
-                const double lnf = d.logNFact_, lp = d.logP_, l1mp = d.log1mP_;
-                d.getProbabilityBatchImpl(vals, res, count, n, lnf, lp, l1mp);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const int n = d.n_;
-            const double lnf = d.logNFact_, lp = d.logP_, l1mp = d.log1mP_;
-            lock.unlock();
+            int n;
+            double lnf, lp, l1mp;
+            d.withCacheSnapshot([&] {
+                n = d.n_;
+                lnf = d.logNFact_;
+                lp = d.logP_;
+                l1mp = d.log1mP_;
+            });
             d.getProbabilityBatchImpl(vals, res, count, n, lnf, lp, l1mp);
         },
         [](const BinomialDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -579,28 +546,7 @@ void BinomialDistribution::getProbability(std::span<const double> values, std::s
             const std::size_t count = vals.size();
             if (count == 0)
                 return;
-            int n;
-            double lnf, lp, l1mp;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    // Snapshot while unique_lock still held — no TOCTOU gap.
-                    n = d.n_;
-                    lnf = d.logNFact_;
-                    lp = d.logP_;
-                    l1mp = d.log1mP_;
-                } else {
-                    // Snapshot under shared_lock.
-                    n = d.n_;
-                    lnf = d.logNFact_;
-                    lp = d.logP_;
-                    l1mp = d.log1mP_;
-                }
-            }
+            // Snapshot vars unused here — batch delegates to scalar getProbability per element.
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     res[i] = d.getProbability(vals[i]);
@@ -609,10 +555,6 @@ void BinomialDistribution::getProbability(std::span<const double> values, std::s
                 for (std::size_t i = 0; i < count; ++i)
                     res[i] = d.getProbability(vals[i]);
             }
-            (void)n;
-            (void)lnf;
-            (void)lp;
-            (void)l1mp;
         },
         [](const BinomialDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
@@ -630,22 +572,14 @@ void BinomialDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const BinomialDistribution& d, double x) { return d.getLogProbability(x); },
         [](const BinomialDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const int n = d.n_;
-                const double lnf = d.logNFact_, lp = d.logP_, l1mp = d.log1mP_;
-                d.getLogProbabilityBatchImpl(vals, res, count, n, lnf, lp, l1mp);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const int n = d.n_;
-            const double lnf = d.logNFact_, lp = d.logP_, l1mp = d.log1mP_;
-            lock.unlock();
+            int n;
+            double lnf, lp, l1mp;
+            d.withCacheSnapshot([&] {
+                n = d.n_;
+                lnf = d.logNFact_;
+                lp = d.logP_;
+                l1mp = d.log1mP_;
+            });
             d.getLogProbabilityBatchImpl(vals, res, count, n, lnf, lp, l1mp);
         },
         [](const BinomialDistribution& d, std::span<const double> vals, std::span<double> res) {

--- a/src/cauchy.cpp
+++ b/src/cauchy.cpp
@@ -207,20 +207,11 @@ double CauchyDistribution::getProbability(double x) const {
     if (std::isnan(x))
         return std::numeric_limits<double>::quiet_NaN();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double x0 = x0_, ig = inv_gamma_;
-        const double z = (x - x0) * ig;
-        return student_t_.getProbability(z) * ig;
-    }
-    const double x0 = x0_, ig = inv_gamma_;
-    lock.unlock();
-    // PDF_Cauchy(x) = PDF_StudentT(1)((x-x0)/gamma) / gamma
+    double x0, ig;
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        ig = inv_gamma_;
+    });
     const double z = (x - x0) * ig;
     return student_t_.getProbability(z) * ig;
 }
@@ -229,20 +220,12 @@ double CauchyDistribution::getLogProbability(double x) const {
     if (std::isnan(x))
         return std::numeric_limits<double>::quiet_NaN();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double x0 = x0_, ig = inv_gamma_, lg = log_gamma_;
-        const double z = (x - x0) * ig;
-        return student_t_.getLogProbability(z) - lg;
-    }
-    const double x0 = x0_, ig = inv_gamma_, lg = log_gamma_;
-    lock.unlock();
-    // LogPDF_Cauchy(x) = LogPDF_StudentT(1)((x-x0)/gamma) - log(gamma)
+    double x0, ig, lg;
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        ig = inv_gamma_;
+        lg = log_gamma_;
+    });
     const double z = (x - x0) * ig;
     return student_t_.getLogProbability(z) - lg;
 }
@@ -251,20 +234,11 @@ double CauchyDistribution::getCumulativeProbability(double x) const {
     if (std::isnan(x))
         return std::numeric_limits<double>::quiet_NaN();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double x0 = x0_, ig = inv_gamma_;
-        const double z = (x - x0) * ig;
-        return student_t_.getCumulativeProbability(z);
-    }
-    const double x0 = x0_, ig = inv_gamma_;
-    lock.unlock();
-    // CDF_Cauchy(x) = CDF_StudentT(1)((x-x0)/gamma)  [exact, no output scaling]
+    double x0, ig;
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        ig = inv_gamma_;
+    });
     const double z = (x - x0) * ig;
     return student_t_.getCumulativeProbability(z);
 }
@@ -277,40 +251,20 @@ double CauchyDistribution::getQuantile(double p) const {
     if (p == detail::ONE)
         return std::numeric_limits<double>::infinity();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double x0 = x0_, g = gamma_;
-        return x0 + g * std::tan(detail::PI * (p - detail::HALF));
-    }
-    const double x0 = x0_, g = gamma_;
-    lock.unlock();
-    // Closed form: x0 + gamma * tan(pi * (p - 0.5))
+    double x0, g;
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        g = gamma_;
+    });
     return x0 + g * std::tan(detail::PI * (p - detail::HALF));
 }
 
 double CauchyDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double x0, g;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            x0 = x0_;
-            g = gamma_;
-        } else {
-            x0 = x0_;
-            g = gamma_;
-        }
-    }
-    // X = x0 + gamma * Z  where Z ~ StudentT(1) ~ Cauchy(0,1)
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        g = gamma_;
+    });
     return x0 + g * student_t_.sample(rng);
 }
 
@@ -318,23 +272,11 @@ std::vector<double> CauchyDistribution::sample(std::mt19937& rng, size_t n) cons
     std::vector<double> samples;
     samples.reserve(n);
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double x0, g;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            x0 = x0_;
-            g = gamma_;
-        } else {
-            x0 = x0_;
-            g = gamma_;
-        }
-    }
-
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        g = gamma_;
+    });
     auto z_samples = student_t_.sample(rng, n);
     for (double z : z_samples)
         samples.push_back(x0 + g * z);
@@ -451,18 +393,9 @@ std::string CauchyDistribution::toString() const {
 //==============================================================================
 
 double CauchyDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double g = gamma_;
-        return std::log(detail::FOUR_PI * g);
-    }
-    // H = log(4πγ)
-    return std::log(detail::FOUR_PI * gamma_);
+    double g;
+    withCacheSnapshot([&] { g = gamma_; });
+    return std::log(detail::FOUR_PI * g);
 }
 
 //==============================================================================
@@ -495,22 +428,11 @@ void CauchyDistribution::getProbability(std::span<const double> values, std::spa
     if (n != results.size())
         throw std::invalid_argument("Input and output spans must have the same size");
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double x0, ig;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            x0 = x0_;
-            ig = inv_gamma_;
-        } else {
-            x0 = x0_;
-            ig = inv_gamma_;
-        }
-    }
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        ig = inv_gamma_;
+    });
 
     // Transform inputs: z[i] = (x[i] - x0) / gamma
     std::vector<double, arch::simd::aligned_allocator<double>> z(n);
@@ -534,24 +456,12 @@ void CauchyDistribution::getLogProbability(std::span<const double> values,
     if (n != results.size())
         throw std::invalid_argument("Input and output spans must have the same size");
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double x0, ig, lg;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            x0 = x0_;
-            ig = inv_gamma_;
-            lg = log_gamma_;
-        } else {
-            x0 = x0_;
-            ig = inv_gamma_;
-            lg = log_gamma_;
-        }
-    }
+    withCacheSnapshot([&] {
+        x0 = x0_;
+        ig = inv_gamma_;
+        lg = log_gamma_;
+    });
 
     std::vector<double, arch::simd::aligned_allocator<double>> z(n);
     using VectorOps = arch::simd::VectorOps;

--- a/src/discrete.cpp
+++ b/src/discrete.cpp
@@ -152,31 +152,15 @@ DiscreteDistribution& DiscreteDistribution::operator=(DiscreteDistribution&& oth
 //==============================================================================
 
 double DiscreteDistribution::getMean() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double m = mean_;
-        return m;
-    }
-    return mean_;
+    double m;
+    withCacheSnapshot([&] { m = mean_; });
+    return m;
 }
 
 double DiscreteDistribution::getVariance() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double v = variance_;
-        return v;
-    }
-    return variance_;
+    double v;
+    withCacheSnapshot([&] { v = variance_; });
+    return v;
 }
 
 void DiscreteDistribution::setLowerBound(int a) {
@@ -237,20 +221,9 @@ double DiscreteDistribution::getSkewness() const {
 }
 
 double DiscreteDistribution::getKurtosis() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double n = static_cast<double>(range_);
-        // Degenerate distribution (n=1): kurtosis is undefined (0/0); return NaN.
-        if (n <= 1.0)
-            return std::numeric_limits<double>::quiet_NaN();
-        return -detail::SIX * (n * n + detail::ONE) / (detail::FIVE * (n * n - detail::ONE));
-    }
-    const double n = static_cast<double>(range_);  // b - a + 1
+    int r;
+    withCacheSnapshot([&] { r = range_; });
+    const double n = static_cast<double>(r);  // b - a + 1
     // Exact excess kurtosis for discrete uniform: -6(n²+1) / (5(n²-1))
     // Approximates -1.2 for large n; gives exact -2.0 for binary (n=2).
     // Degenerate distribution (n=1): undefined (0/0); return NaN.
@@ -295,31 +268,15 @@ double DiscreteDistribution::getEntropy() const {
 }
 
 int DiscreteDistribution::getRange() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int r = range_;
-        return r;
-    }
-    return range_;
+    int r;
+    withCacheSnapshot([&] { r = range_; });
+    return r;
 }
 
 double DiscreteDistribution::getSingleOutcomeProbability() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double p = probability_;
-        return p;
-    }
-    return probability_;
+    double p;
+    withCacheSnapshot([&] { p = probability_; });
+    return p;
 }
 
 //==============================================================================
@@ -425,28 +382,20 @@ double DiscreteDistribution::getProbability(double x) const {
 
     const int k = static_cast<int>(x);  // safe: x is finite integer
 
-    // Acquire lock before reading a_/b_ — prevents data race with concurrent setters
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int a = a_, b = b_;
-        const bool is_binary = isBinary_;
-        const double prob = probability_;
-        if (k < a || k > b)
-            return detail::ZERO_DOUBLE;
-        if (is_binary)
-            return detail::HALF;
-        return prob;
-    }
-    if (k < a_ || k > b_)
+    int a, b;
+    bool is_binary;
+    double prob;
+    withCacheSnapshot([&] {
+        a = a_;
+        b = b_;
+        is_binary = isBinary_;
+        prob = probability_;
+    });
+    if (k < a || k > b)
         return detail::ZERO_DOUBLE;
-    if (isBinary_)
+    if (is_binary)
         return detail::HALF;
-    return probability_;  // 1/(b-a+1)
+    return prob;
 }
 
 double DiscreteDistribution::getLogProbability(double x) const {
@@ -459,28 +408,20 @@ double DiscreteDistribution::getLogProbability(double x) const {
 
     const int k = static_cast<int>(x);  // safe: x is finite integer
 
-    // Acquire lock before reading a_/b_ — prevents data race with concurrent setters
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int a = a_, b = b_;
-        const bool is_binary = isBinary_;
-        const double logprob = logProbability_;
-        if (k < a || k > b)
-            return detail::NEGATIVE_INFINITY;
-        if (is_binary)
-            return -detail::LN2;
-        return logprob;
-    }
-    if (k < a_ || k > b_)
+    int a, b;
+    bool is_binary;
+    double logprob;
+    withCacheSnapshot([&] {
+        a = a_;
+        b = b_;
+        is_binary = isBinary_;
+        logprob = logProbability_;
+    });
+    if (k < a || k > b)
         return detail::NEGATIVE_INFINITY;
-    if (isBinary_)
+    if (is_binary)
         return -detail::LN2;
-    return logProbability_;  // -log(b-a+1)
+    return logprob;
 }
 
 double DiscreteDistribution::getCumulativeProbability(double x) const {
@@ -491,30 +432,20 @@ double DiscreteDistribution::getCumulativeProbability(double x) const {
         return (x > 0 ? detail::ONE : detail::ZERO_DOUBLE);
     }
 
-    // Acquire lock before reading a_/b_ — prevents data race with concurrent setters (R5-D1)
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int a = a_, b = b_, range = range_;
-        if (x < static_cast<double>(a))
-            return detail::ZERO_DOUBLE;
-        if (x >= static_cast<double>(b))
-            return detail::ONE;
-        const int k = static_cast<int>(std::floor(x));
-        return static_cast<double>(k - a + detail::ONE_INT) / static_cast<double>(range);
-    }
-    if (x < static_cast<double>(a_))
+    int a, b, range;
+    withCacheSnapshot([&] {
+        a = a_;
+        b = b_;
+        range = range_;
+    });
+    if (x < static_cast<double>(a))
         return detail::ZERO_DOUBLE;
-    if (x >= static_cast<double>(b_))
+    if (x >= static_cast<double>(b))
         return detail::ONE;
     // For discrete uniform: F(k) = (floor(k) - a + 1) / (b - a + 1)
     const int k = static_cast<int>(std::floor(x));
-    const int numerator = k - a_ + detail::ONE_INT;
-    return static_cast<double>(numerator) / static_cast<double>(range_);
+    const int numerator = k - a + detail::ONE_INT;
+    return static_cast<double>(numerator) / static_cast<double>(range);
 }
 
 double DiscreteDistribution::getQuantile(double p) const {
@@ -522,46 +453,26 @@ double DiscreteDistribution::getQuantile(double p) const {
         throw std::invalid_argument("Probability must be between 0 and 1");
     }
 
-    // Ensure cache is valid — a_ and b_ must be read under the lock (R5-D1)
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const int range = range_, a = a_;
-        const double scaled = p * static_cast<double>(range);
-        const int kk = static_cast<int>(std::ceil(scaled)) - 1;
-        return static_cast<double>(a + std::max(0, std::min(kk, range - 1)));
-    }
+    int range, a;
+    withCacheSnapshot([&] {
+        range = range_;
+        a = a_;
+    });
     // For discrete uniform: quantile(p) = a + ceil(p * (b-a+1)) - 1
     // But we need to handle edge cases carefully
-    const double scaled = p * static_cast<double>(range_);
+    const double scaled = p * static_cast<double>(range);
     const int k = static_cast<int>(std::ceil(scaled)) - 1;
-    return static_cast<double>(a_ + std::max(0, std::min(k, range_ - 1)));
+    return static_cast<double>(a + std::max(0, std::min(k, range - 1)));
 }
 
 double DiscreteDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     int a, b;
     bool is_binary;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            is_binary = isBinary_;
-            a = a_;
-            b = b_;
-        } else {
-            is_binary = isBinary_;
-            a = a_;
-            b = b_;
-        }
-    }
+    withCacheSnapshot([&] {
+        is_binary = isBinary_;
+        a = a_;
+        b = b_;
+    });
 
     // Fast path for binary distribution
     if (is_binary) {
@@ -577,25 +488,13 @@ double DiscreteDistribution::sample(std::mt19937& rng) const {
 std::vector<double> DiscreteDistribution::sample(std::mt19937& rng, std::size_t n) const {
     std::vector<double> samples(n);
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     int a, b;
     bool is_binary;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            is_binary = isBinary_;
-            a = a_;
-            b = b_;
-        } else {
-            is_binary = isBinary_;
-            a = a_;
-            b = b_;
-        }
-    }
+    withCacheSnapshot([&] {
+        is_binary = isBinary_;
+        a = a_;
+        b = b_;
+    });
 
     // Fast path for binary distribution
     if (is_binary) {
@@ -807,25 +706,13 @@ std::tuple<double, double, bool> DiscreteDistribution::chiSquaredGoodnessOfFitTe
 std::vector<int> DiscreteDistribution::sampleIntegers(std::mt19937& rng, std::size_t count) const {
     std::vector<int> samples(count);
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     int a, b;
     bool is_binary;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            is_binary = isBinary_;
-            a = a_;
-            b = b_;
-        } else {
-            is_binary = isBinary_;
-            a = a_;
-            b = b_;
-        }
-    }
+    withCacheSnapshot([&] {
+        is_binary = isBinary_;
+        a = a_;
+        b = b_;
+    });
 
     // Fast path for binary distribution
     if (is_binary) {
@@ -924,26 +811,13 @@ void DiscreteDistribution::getProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::PDF,
         [](const DiscreteDistribution& dist, double value) { return dist.getProbability(value); },
         [](const DiscreteDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const int cached_a = dist.a_;
-                const int cached_b = dist.b_;
-                const double cached_prob = dist.probability_;
-                dist.getProbabilityBatchUnsafeImpl(vals, res, count, cached_a, cached_b,
-                                                   cached_prob);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const int cached_a = dist.a_;
-            const int cached_b = dist.b_;
-            const double cached_prob = dist.probability_;
-            lock.unlock();
-            // Call private implementation directly
+            int cached_a, cached_b;
+            double cached_prob;
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_prob = dist.probability_;
+            });
             dist.getProbabilityBatchUnsafeImpl(vals, res, count, cached_a, cached_b, cached_prob);
         },
         [](const DiscreteDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -955,25 +829,13 @@ void DiscreteDistribution::getProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             int cached_a, cached_b;
             double cached_prob;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_prob = dist.probability_;
-                } else {
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_prob = dist.probability_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_prob = dist.probability_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -1011,25 +873,13 @@ void DiscreteDistribution::getProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             int cached_a, cached_b;
             double cached_prob;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_prob = dist.probability_;
-                } else {
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_prob = dist.probability_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_prob = dist.probability_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
@@ -1053,26 +903,13 @@ void DiscreteDistribution::getLogProbability(std::span<const double> values,
             return dist.getLogProbability(value);
         },
         [](const DiscreteDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const int cached_a = dist.a_;
-                const int cached_b = dist.b_;
-                const double cached_log_prob = dist.logProbability_;
-                dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, cached_a, cached_b,
-                                                      cached_log_prob);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const int cached_a = dist.a_;
-            const int cached_b = dist.b_;
-            const double cached_log_prob = dist.logProbability_;
-            lock.unlock();
-            // Call private implementation directly
+            int cached_a, cached_b;
+            double cached_log_prob;
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_log_prob = dist.logProbability_;
+            });
             dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, cached_a, cached_b,
                                                   cached_log_prob);
         },
@@ -1085,28 +922,15 @@ void DiscreteDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             int cached_a, cached_b;
             double cached_log_prob;
             bool cached_is_binary;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_log_prob = dist.logProbability_;
-                    cached_is_binary = dist.isBinary_;
-                } else {
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_log_prob = dist.logProbability_;
-                    cached_is_binary = dist.isBinary_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_log_prob = dist.logProbability_;
+                cached_is_binary = dist.isBinary_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -1150,28 +974,15 @@ void DiscreteDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             int cached_a, cached_b;
             double cached_log_prob;
             bool cached_is_binary;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_log_prob = dist.logProbability_;
-                    cached_is_binary = dist.isBinary_;
-                } else {
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_log_prob = dist.logProbability_;
-                    cached_is_binary = dist.isBinary_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_log_prob = dist.logProbability_;
+                cached_is_binary = dist.isBinary_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
@@ -1199,26 +1010,13 @@ void DiscreteDistribution::getCumulativeProbability(std::span<const double> valu
             return dist.getCumulativeProbability(value);
         },
         [](const DiscreteDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const int cached_a = dist.a_;
-                const int cached_b = dist.b_;
-                const double cached_inv_range = detail::ONE / static_cast<double>(dist.range_);
-                dist.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, cached_a, cached_b,
-                                                             cached_inv_range);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const int cached_a = dist.a_;
-            const int cached_b = dist.b_;
-            const double cached_inv_range = detail::ONE / static_cast<double>(dist.range_);
-            lock.unlock();
-            // Call private implementation directly
+            int cached_a, cached_b, cached_range;
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_range = dist.range_;
+            });
+            const double cached_inv_range = detail::ONE / static_cast<double>(cached_range);
             dist.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, cached_a, cached_b,
                                                          cached_inv_range);
         },
@@ -1231,24 +1029,12 @@ void DiscreteDistribution::getCumulativeProbability(std::span<const double> valu
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             int cached_a, cached_b, cached_range;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_range = dist.range_;
-                } else {
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_range = dist.range_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_range = dist.range_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -1288,24 +1074,12 @@ void DiscreteDistribution::getCumulativeProbability(std::span<const double> valu
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             int cached_a, cached_b, cached_range;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_range = dist.range_;
-                } else {
-                    cached_a = dist.a_;
-                    cached_b = dist.b_;
-                    cached_range = dist.range_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_a = dist.a_;
+                cached_b = dist.b_;
+                cached_range = dist.range_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {

--- a/src/exponential.cpp
+++ b/src/exponential.cpp
@@ -185,28 +185,16 @@ double ExponentialDistribution::getProbability(double x) const {
         return detail::ZERO_DOUBLE;
     }
 
-    // Ensure cache is valid
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_unit = isUnitRate_;
-        const double lam = lambda_, neg_lam = negLambda_;
-        if (is_unit)
-            return std::exp(-x);
-        return lam * std::exp(neg_lam * x);
-    }
-
-    // Fast path for unit exponential (λ = 1)
-    if (isUnitRate_) {
+    bool is_unit;
+    double lam, neg_lam;
+    withCacheSnapshot([&] {
+        is_unit = isUnitRate_;
+        lam = lambda_;
+        neg_lam = negLambda_;
+    });
+    if (is_unit)
         return std::exp(-x);
-    }
-
-    // General case: f(x) = λ * exp(-λx)
-    return lambda_ * std::exp(negLambda_ * x);
+    return lam * std::exp(neg_lam * x);
 }
 
 double ExponentialDistribution::getLogProbability(double x) const {
@@ -215,28 +203,16 @@ double ExponentialDistribution::getLogProbability(double x) const {
         return detail::NEGATIVE_INFINITY;
     }
 
-    // Ensure cache is valid
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_unit = isUnitRate_;
-        const double log_lam = logLambda_, neg_lam = negLambda_;
-        if (is_unit)
-            return -x;
-        return log_lam + neg_lam * x;
-    }
-
-    // Fast path for unit exponential (λ = 1)
-    if (isUnitRate_) {
+    bool is_unit;
+    double log_lam, neg_lam;
+    withCacheSnapshot([&] {
+        is_unit = isUnitRate_;
+        log_lam = logLambda_;
+        neg_lam = negLambda_;
+    });
+    if (is_unit)
         return -x;
-    }
-
-    // General case: log(f(x)) = log(λ) - λx
-    return logLambda_ + negLambda_ * x;
+    return log_lam + neg_lam * x;
 }
 
 double ExponentialDistribution::getCumulativeProbability(double x) const {
@@ -245,28 +221,15 @@ double ExponentialDistribution::getCumulativeProbability(double x) const {
         return detail::ZERO_DOUBLE;
     }
 
-    // Ensure cache is valid
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_unit = isUnitRate_;
-        const double neg_lam = negLambda_;
-        if (is_unit)
-            return detail::ONE - std::exp(-x);
-        return detail::ONE - std::exp(neg_lam * x);
-    }
-
-    // Fast path for unit exponential (λ = 1)
-    if (isUnitRate_) {
+    bool is_unit;
+    double neg_lam;
+    withCacheSnapshot([&] {
+        is_unit = isUnitRate_;
+        neg_lam = negLambda_;
+    });
+    if (is_unit)
         return detail::ONE - std::exp(-x);
-    }
-
-    // General case: F(x) = 1 - exp(-λx)
-    return detail::ONE - std::exp(negLambda_ * x);
+    return detail::ONE - std::exp(neg_lam * x);
 }
 
 double ExponentialDistribution::getQuantile(double p) const {
@@ -281,60 +244,28 @@ double ExponentialDistribution::getQuantile(double p) const {
         return std::numeric_limits<double>::infinity();
     }
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_unit = isUnitRate_;
-        const double inv_lam = invLambda_;
-        if (is_unit)
-            return -std::log(detail::ONE - p);
-        return -std::log(detail::ONE - p) * inv_lam;
-    }
-
-    // Fast path for unit exponential (λ = 1)
-    if (isUnitRate_) {
+    bool is_unit;
+    double inv_lam;
+    withCacheSnapshot([&] {
+        is_unit = isUnitRate_;
+        inv_lam = invLambda_;
+    });
+    if (is_unit)
         return -std::log(detail::ONE - p);
-    }
-
-    // General case: F^(-1)(p) = -ln(1-p)/λ
-    return -std::log(detail::ONE - p) * invLambda_;
+    return -std::log(detail::ONE - p) * inv_lam;
 }
 
 double ExponentialDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     bool cached_is_unit_rate;
     double cached_inv_lambda;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_is_unit_rate = isUnitRate_;
-            cached_inv_lambda = invLambda_;
-        } else {
-            cached_is_unit_rate = isUnitRate_;
-            cached_inv_lambda = invLambda_;
-        }
-    }
-
-    // Use high-quality uniform distribution
+    withCacheSnapshot([&] {
+        cached_is_unit_rate = isUnitRate_;
+        cached_inv_lambda = invLambda_;
+    });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
-
-    double u = uniform(rng);
-
-    // Fast path for unit exponential (λ = 1)
-    if (cached_is_unit_rate) {
+    const double u = uniform(rng);
+    if (cached_is_unit_rate)
         return -std::log(u);
-    }
-
-    // General case: inverse transform sampling
-    // X = -ln(U)/λ where U ~ Uniform(0,1)
     return -std::log(u) * cached_inv_lambda;
 }
 
@@ -342,23 +273,12 @@ std::vector<double> ExponentialDistribution::sample(std::mt19937& rng, size_t n)
     std::vector<double> samples;
     samples.reserve(n);
 
-    // Snapshot cached fields; no re-acquire = no TOCTOU gap.
     bool cached_is_unit_rate;
     double cached_inv_lambda;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_is_unit_rate = isUnitRate_;
-            cached_inv_lambda = invLambda_;
-        } else {
-            cached_is_unit_rate = isUnitRate_;
-            cached_inv_lambda = invLambda_;
-        }
-    }
+    withCacheSnapshot([&] {
+        cached_is_unit_rate = isUnitRate_;
+        cached_inv_lambda = invLambda_;
+    });
 
     // Use high-quality uniform distribution for batch generation
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);

--- a/src/gamma.cpp
+++ b/src/gamma.cpp
@@ -107,51 +107,27 @@ GammaDistribution& GammaDistribution::operator=(GammaDistribution&& other) noexc
 //==========================================================================
 
 double GammaDistribution::getScale() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return scale_;  // snapshot + early return under unique_lock
-    }
-    return scale_;
+    double sc;
+    withCacheSnapshot([&] { sc = scale_; });
+    return sc;
 }
 
 double GammaDistribution::getMean() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return mean_;  // snapshot + early return under unique_lock
-    }
-    return mean_;
+    double m;
+    withCacheSnapshot([&] { m = mean_; });
+    return m;
 }
 
 double GammaDistribution::getVariance() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return variance_;  // snapshot + early return under unique_lock
-    }
-    return variance_;
+    double v;
+    withCacheSnapshot([&] { v = variance_; });
+    return v;
 }
 
 double GammaDistribution::getSkewness() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return detail::TWO / sqrtAlpha_;  // snapshot + early return under unique_lock
-    }
-    return detail::TWO / sqrtAlpha_;
+    double sa;
+    withCacheSnapshot([&] { sa = sqrtAlpha_; });
+    return detail::TWO / sa;
 }
 
 double GammaDistribution::getKurtosis() const {
@@ -297,34 +273,22 @@ double GammaDistribution::getProbability(double x) const {
         return detail::ZERO_DOUBLE;
     }
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot under unique_lock — eliminates TOCTOU gap.
-        // Inline log-space formula instead of calling getLogProbability to
-        // avoid re-entrant shared_lock acquisition on the same mutex.
-        const double a = alpha_, b = beta_;
-        const double alb = alphaLogBeta_, lga = logGammaAlpha_, am1 = alphaMinusOne_;
-        if (x == detail::ZERO_DOUBLE) {
-            return (a < detail::ONE)    ? std::numeric_limits<double>::infinity()
-                   : (a == detail::ONE) ? b
-                                        : detail::ZERO_DOUBLE;
-        }
-        return std::exp(alb - lga + am1 * std::log(x) - b * x);
-    }
-
+    double a, b, alb, lga, am1;
+    withCacheSnapshot([&] {
+        a = alpha_;
+        b = beta_;
+        alb = alphaLogBeta_;
+        lga = logGammaAlpha_;
+        am1 = alphaMinusOne_;
+    });
     // Handle special case x = 0
     if (x == detail::ZERO_DOUBLE) {
-        return (alpha_ < detail::ONE)    ? std::numeric_limits<double>::infinity()
-               : (alpha_ == detail::ONE) ? beta_
-                                         : detail::ZERO_DOUBLE;
+        return (a < detail::ONE)    ? std::numeric_limits<double>::infinity()
+               : (a == detail::ONE) ? b
+                                    : detail::ZERO_DOUBLE;
     }
-
-    // Inline log-space computation (avoids re-entrant lock via getLogProbability).
-    return std::exp(alphaLogBeta_ - logGammaAlpha_ + alphaMinusOne_ * std::log(x) - beta_ * x);
+    // Inline log-space computation.
+    return std::exp(alb - lga + am1 * std::log(x) - b * x);
 }
 
 double GammaDistribution::getLogProbability(double x) const {
@@ -332,39 +296,26 @@ double GammaDistribution::getLogProbability(double x) const {
         return detail::NEGATIVE_INFINITY;
     }
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot under unique_lock — eliminates TOCTOU gap.
-        const double a = alpha_, b = beta_;
-        const double lb = logBeta_, alb = alphaLogBeta_, lga = logGammaAlpha_, am1 = alphaMinusOne_;
-        if (x == detail::ZERO_DOUBLE) {
-            if (a < detail::ONE)
-                return std::numeric_limits<double>::infinity();
-            else if (a == detail::ONE)
-                return lb;
-            else
-                return detail::MIN_LOG_PROBABILITY;
-        }
-        return alb - lga + am1 * std::log(x) - b * x;
-    }
-
+    double a, b, lb, alb, lga, am1;
+    withCacheSnapshot([&] {
+        a = alpha_;
+        b = beta_;
+        lb = logBeta_;
+        alb = alphaLogBeta_;
+        lga = logGammaAlpha_;
+        am1 = alphaMinusOne_;
+    });
     // Handle special case x = 0
     if (x == detail::ZERO_DOUBLE) {
-        if (alpha_ < detail::ONE) {
+        if (a < detail::ONE)
             return std::numeric_limits<double>::infinity();
-        } else if (alpha_ == detail::ONE) {
-            return logBeta_;  // log(β)
-        } else {
+        else if (a == detail::ONE)
+            return lb;
+        else
             return detail::MIN_LOG_PROBABILITY;
-        }
     }
-
     // General case: log(f(x)) = α*log(β) - log(Γ(α)) + (α-1)*log(x) - βx
-    return alphaLogBeta_ - logGammaAlpha_ + alphaMinusOne_ * std::log(x) - beta_ * x;
+    return alb - lga + am1 * std::log(x) - b * x;
 }
 
 double GammaDistribution::getCumulativeProbability(double x) const {
@@ -380,18 +331,13 @@ double GammaDistribution::getCumulativeProbability(double x) const {
         return detail::ZERO_DOUBLE;
     }
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot under unique_lock — eliminates TOCTOU gap.
-        const double a = alpha_, b = beta_;
-        return detail::gamma_p(a, b * x);
-    }
+    double a, b;
+    withCacheSnapshot([&] {
+        a = alpha_;
+        b = beta_;
+    });
     // Use regularized incomplete gamma function P(α, βx)
-    return detail::gamma_p(alpha_, beta_ * x);
+    return detail::gamma_p(a, b * x);
 }
 
 double GammaDistribution::getQuantile(double p) const {
@@ -411,22 +357,11 @@ double GammaDistribution::getQuantile(double p) const {
 }
 
 double GammaDistribution::sample(std::mt19937& rng) const {
-    // Snapshot alpha, beta under the appropriate lock to avoid TOCTOU.
     double cached_alpha, cached_beta;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_alpha = alpha_;
-            cached_beta = beta_;
-        } else {
-            cached_alpha = alpha_;
-            cached_beta = beta_;
-        }
-    }
+    withCacheSnapshot([&] {
+        cached_alpha = alpha_;
+        cached_beta = beta_;
+    });
 
     // Choose sampling method based on cached α — lock released.
     // Inline the sampling algorithms using cached parameters to avoid
@@ -477,22 +412,11 @@ double GammaDistribution::sample(std::mt19937& rng) const {
 }
 
 std::vector<double> GammaDistribution::sample(std::mt19937& rng, size_t n) const {
-    // Snapshot alpha, beta under the appropriate lock to avoid TOCTOU.
     double cached_alpha, cached_beta;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_alpha = alpha_;
-            cached_beta = beta_;  // snapshot under unique_lock
-        } else {
-            cached_alpha = alpha_;
-            cached_beta = beta_;  // snapshot under shared_lock
-        }
-    }
+    withCacheSnapshot([&] {
+        cached_alpha = alpha_;
+        cached_beta = beta_;
+    });
 
     std::vector<double> samples;
     samples.reserve(n);
@@ -690,27 +614,15 @@ GammaDistribution::GammaDistribution(double alpha, double beta, bool /*bypassVal
 }
 
 bool GammaDistribution::isExponentialDistribution() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return isExponential_;  // snapshot + early return under unique_lock
-    }
-    return isExponential_;
+    bool ie;
+    withCacheSnapshot([&] { ie = isExponential_; });
+    return ie;
 }
 
 bool GammaDistribution::isChiSquaredDistribution() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return isChiSquared_;  // snapshot + early return under unique_lock
-    }
-    return isChiSquared_;
+    bool ics;
+    withCacheSnapshot([&] { ics = isChiSquared_; });
+    return ics;
 }
 
 double GammaDistribution::getDegreesOfFreedom() const {
@@ -723,30 +635,21 @@ double GammaDistribution::getDegreesOfFreedom() const {
 }
 
 double GammaDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot under unique_lock — eliminates TOCTOU gap.
-        const double a = alpha_, lb = logBeta_, lga = logGammaAlpha_, da = digammaAlpha_;
-        return a - lb + lga + (detail::ONE - a) * da;
-    }
+    double a, lb, lga, da;
+    withCacheSnapshot([&] {
+        a = alpha_;
+        lb = logBeta_;
+        lga = logGammaAlpha_;
+        da = digammaAlpha_;
+    });
     // H(X) = α - log(β) + log(Γ(α)) + (1-α)ψ(α)
-    return alpha_ - logBeta_ + logGammaAlpha_ + (detail::ONE - alpha_) * digammaAlpha_;
+    return a - lb + lga + (detail::ONE - a) * da;
 }
 
 bool GammaDistribution::canUseNormalApproximation() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return isLargeAlpha_;  // snapshot + early return under unique_lock
-    }
-    return isLargeAlpha_;
+    bool la;
+    withCacheSnapshot([&] { la = isLargeAlpha_; });
+    return la;
 }
 
 Result<GammaDistribution> GammaDistribution::createFromMoments(double mean,
@@ -777,25 +680,14 @@ void GammaDistribution::getProbability(std::span<const double> values, std::span
         *this, values, results, hint, detail::OperationType::PDF,
         [](const GammaDistribution& dist, double value) { return dist.getProbability(value); },
         [](const GammaDistribution& dist, const double* vals, double* res, size_t count) {
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot under unique_lock.
-                const double alpha = dist.alpha_, beta = dist.beta_;
-                const double lga = dist.logGammaAlpha_, alb = dist.alphaLogBeta_;
-                const double am1 = dist.alphaMinusOne_;
-                dist.getProbabilityBatchUnsafeImpl(vals, res, count, alpha, beta, lga, alb, am1);
-                return;  // early return; ulock releases here
-            }
-            // Cache hit — snapshot under shared_lock, then unlock.
-            const double alpha = dist.alpha_, beta = dist.beta_;
-            const double lga = dist.logGammaAlpha_, alb = dist.alphaLogBeta_;
-            const double am1 = dist.alphaMinusOne_;
-            lock.unlock();
+            double alpha, beta, lga, alb, am1;
+            dist.withCacheSnapshot([&] {
+                alpha = dist.alpha_;
+                beta = dist.beta_;
+                lga = dist.logGammaAlpha_;
+                alb = dist.alphaLogBeta_;
+                am1 = dist.alphaMinusOne_;
+            });
             dist.getProbabilityBatchUnsafeImpl(vals, res, count, alpha, beta, lga, alb, am1);
         },
         [](const GammaDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -808,30 +700,16 @@ void GammaDistribution::getProbability(std::span<const double> values, std::span
             if (count == 0)
                 return;
 
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
             [[maybe_unused]] double cached_alpha;
             double cached_beta, cached_log_gamma_alpha, cached_alpha_log_beta,
                 cached_alpha_minus_one;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                } else {
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_alpha = dist.alpha_;
+                cached_beta = dist.beta_;
+                cached_log_gamma_alpha = dist.logGammaAlpha_;
+                cached_alpha_log_beta = dist.alphaLogBeta_;
+                cached_alpha_minus_one = dist.alphaMinusOne_;
+            });
 
             // Chunk so each parallel task runs the SIMD log+exp pipeline
             // rather than computing log(x) per element in each task.
@@ -862,29 +740,15 @@ void GammaDistribution::getProbability(std::span<const double> values, std::span
             if (count == 0)
                 return;
 
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
             double cached_alpha, cached_beta, cached_log_gamma_alpha;
             double cached_alpha_log_beta, cached_alpha_minus_one;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                } else {
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_alpha = dist.alpha_;
+                cached_beta = dist.beta_;
+                cached_log_gamma_alpha = dist.logGammaAlpha_;
+                cached_alpha_log_beta = dist.alphaLogBeta_;
+                cached_alpha_minus_one = dist.alphaMinusOne_;
+            });
 
             // Chunk into SIMD-sized slices so pool tasks use the SIMD pipeline.
             constexpr std::size_t CHUNK = 1024;
@@ -906,25 +770,14 @@ void GammaDistribution::getLogProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const GammaDistribution& dist, double value) { return dist.getLogProbability(value); },
         [](const GammaDistribution& dist, const double* vals, double* res, size_t count) {
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot under unique_lock.
-                const double alpha = dist.alpha_, beta = dist.beta_;
-                const double lga = dist.logGammaAlpha_, alb = dist.alphaLogBeta_;
-                const double am1 = dist.alphaMinusOne_;
-                dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, alpha, beta, lga, alb, am1);
-                return;  // early return; ulock releases here
-            }
-            // Cache hit — snapshot under shared_lock, then unlock.
-            const double alpha = dist.alpha_, beta = dist.beta_;
-            const double lga = dist.logGammaAlpha_, alb = dist.alphaLogBeta_;
-            const double am1 = dist.alphaMinusOne_;
-            lock.unlock();
+            double alpha, beta, lga, alb, am1;
+            dist.withCacheSnapshot([&] {
+                alpha = dist.alpha_;
+                beta = dist.beta_;
+                lga = dist.logGammaAlpha_;
+                alb = dist.alphaLogBeta_;
+                am1 = dist.alphaMinusOne_;
+            });
             dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, alpha, beta, lga, alb, am1);
         },
         [](const GammaDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -937,29 +790,15 @@ void GammaDistribution::getLogProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
 
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
             double cached_alpha, cached_beta, cached_log_gamma_alpha;
             double cached_alpha_log_beta, cached_alpha_minus_one;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                } else {
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_alpha = dist.alpha_;
+                cached_beta = dist.beta_;
+                cached_log_gamma_alpha = dist.logGammaAlpha_;
+                cached_alpha_log_beta = dist.alphaLogBeta_;
+                cached_alpha_minus_one = dist.alphaMinusOne_;
+            });
 
             // Chunk so each parallel task runs the SIMD log pipeline.
             constexpr std::size_t CHUNK = 1024;
@@ -989,29 +828,15 @@ void GammaDistribution::getLogProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
 
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
             double cached_alpha, cached_beta, cached_log_gamma_alpha;
             double cached_alpha_log_beta, cached_alpha_minus_one;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                } else {
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                    cached_log_gamma_alpha = dist.logGammaAlpha_;
-                    cached_alpha_log_beta = dist.alphaLogBeta_;
-                    cached_alpha_minus_one = dist.alphaMinusOne_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_alpha = dist.alpha_;
+                cached_beta = dist.beta_;
+                cached_log_gamma_alpha = dist.logGammaAlpha_;
+                cached_alpha_log_beta = dist.alphaLogBeta_;
+                cached_alpha_minus_one = dist.alphaMinusOne_;
+            });
 
             constexpr std::size_t CHUNK = 1024;
             const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
@@ -1035,21 +860,11 @@ void GammaDistribution::getCumulativeProbability(std::span<const double> values,
             return dist.getCumulativeProbability(value);
         },
         [](const GammaDistribution& dist, const double* vals, double* res, size_t count) {
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot under unique_lock.
-                const double alpha = dist.alpha_, beta = dist.beta_;
-                dist.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, alpha, beta);
-                return;  // early return; ulock releases here
-            }
-            // Cache hit — snapshot under shared_lock, then unlock.
-            const double alpha = dist.alpha_, beta = dist.beta_;
-            lock.unlock();
+            double alpha, beta;
+            dist.withCacheSnapshot([&] {
+                alpha = dist.alpha_;
+                beta = dist.beta_;
+            });
             dist.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, alpha, beta);
         },
         [](const GammaDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -1062,22 +877,11 @@ void GammaDistribution::getCumulativeProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
             double cached_alpha, cached_beta;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                } else {
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_alpha = dist.alpha_;
+                cached_beta = dist.beta_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -1112,22 +916,11 @@ void GammaDistribution::getCumulativeProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            // Snapshot cache fields under the appropriate lock — no TOCTOU gap.
             double cached_alpha, cached_beta;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                } else {
-                    cached_alpha = dist.alpha_;
-                    cached_beta = dist.beta_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_alpha = dist.alpha_;
+                cached_beta = dist.beta_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {

--- a/src/gaussian.cpp
+++ b/src/gaussian.cpp
@@ -701,30 +701,14 @@ void GaussianDistribution::getProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::PDF,
         [](const GaussianDistribution& dist, double value) { return dist.getProbability(value); },
         [](const GaussianDistribution& dist, const double* vals, double* res, size_t count) {
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_norm_constant, cached_neg_half_inv_var;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_norm_constant = dist.normalizationConstant_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_norm_constant = dist.normalizationConstant_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_norm_constant = dist.normalizationConstant_;
+                cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Call private implementation directly
             dist.getProbabilityBatchUnsafeImpl(vals, res, count, cached_mean, cached_norm_constant,
@@ -740,30 +724,14 @@ void GaussianDistribution::getProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
 
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_norm_constant, cached_neg_half_inv_var;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_norm_constant = dist.normalizationConstant_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_norm_constant = dist.normalizationConstant_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_norm_constant = dist.normalizationConstant_;
+                cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -802,30 +770,14 @@ void GaussianDistribution::getProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
 
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_norm_constant, cached_neg_half_inv_var;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_norm_constant = dist.normalizationConstant_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_norm_constant = dist.normalizationConstant_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_norm_constant = dist.normalizationConstant_;
+                cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
@@ -851,30 +803,14 @@ void GaussianDistribution::getLogProbability(std::span<const double> values,
             return dist.getLogProbability(value);
         },
         [](const GaussianDistribution& dist, const double* vals, double* res, size_t count) {
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_log_std, cached_neg_half_inv_var;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_log_std = dist.logStandardDeviation_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_log_std = dist.logStandardDeviation_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_log_std = dist.logStandardDeviation_;
+                cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Call private implementation directly
             dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, cached_mean, cached_log_std,
@@ -891,30 +827,14 @@ void GaussianDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_log_std, cached_neg_half_inv_var;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_log_std = dist.logStandardDeviation_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_log_std = dist.logStandardDeviation_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_log_std = dist.logStandardDeviation_;
+                cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -955,30 +875,14 @@ void GaussianDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_log_std, cached_neg_half_inv_var;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_log_std = dist.logStandardDeviation_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_log_std = dist.logStandardDeviation_;
-                    cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_log_std = dist.logStandardDeviation_;
+                cached_neg_half_inv_var = dist.negHalfSigmaSquaredInv_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
@@ -1005,28 +909,13 @@ void GaussianDistribution::getCumulativeProbability(std::span<const double> valu
             return dist.getCumulativeProbability(value);
         },
         [](const GaussianDistribution& dist, const double* vals, double* res, size_t count) {
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_sigma_sqrt2;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_sigma_sqrt2 = dist.sigmaSqrt2_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_sigma_sqrt2 = dist.sigmaSqrt2_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_sigma_sqrt2 = dist.sigmaSqrt2_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Call private implementation directly
             dist.getCumulativeProbabilityBatchUnsafeImpl(
@@ -1042,28 +931,13 @@ void GaussianDistribution::getCumulativeProbability(std::span<const double> valu
             if (count == 0)
                 return;
 
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_sigma_sqrt2;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_sigma_sqrt2 = dist.sigmaSqrt2_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_sigma_sqrt2 = dist.sigmaSqrt2_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_sigma_sqrt2 = dist.sigmaSqrt2_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Use ParallelUtils::parallelFor for Level 0-3 integration
             if (arch::should_use_parallel(count)) {
@@ -1100,28 +974,13 @@ void GaussianDistribution::getCumulativeProbability(std::span<const double> valu
             if (count == 0)
                 return;
 
-            // Ensure cache is valid and snapshot atomically — no TOCTOU gap.
             double cached_mean, cached_sigma_sqrt2;
             bool cached_is_standard_normal;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    // Snapshot while unique_lock is still held — no TOCTOU gap.
-                    cached_mean = dist.mean_;
-                    cached_sigma_sqrt2 = dist.sigmaSqrt2_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                } else {
-                    // Snapshot under shared_lock.
-                    cached_mean = dist.mean_;
-                    cached_sigma_sqrt2 = dist.sigmaSqrt2_;
-                    cached_is_standard_normal = dist.isStandardNormal_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                cached_mean = dist.mean_;
+                cached_sigma_sqrt2 = dist.sigmaSqrt2_;
+                cached_is_standard_normal = dist.isStandardNormal_;
+            });
 
             // Use work-stealing pool for dynamic load balancing
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {

--- a/src/gaussian.cpp
+++ b/src/gaussian.cpp
@@ -241,81 +241,46 @@ double GaussianDistribution::getSupportUpperBound() const noexcept {
 //==============================================================================
 
 double GaussianDistribution::getProbability(double x) const {
-    // Snapshot cached fields under the appropriate lock; no re-acquire = no TOCTOU gap.
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_std = isStandardNormal_;
-        const double m = mean_, norm = normalizationConstant_;
-        const double neg_half = negHalfSigmaSquaredInv_;
-        if (is_std)
-            return detail::INV_SQRT_2PI * std::exp(detail::NEG_HALF * x * x);
-        const double diff = x - m;
-        return norm * std::exp(neg_half * diff * diff);
-    }
-    // Fast path for standard normal
-    if (isStandardNormal_) {
-        const double sq_diff = x * x;
-        return detail::INV_SQRT_2PI * std::exp(detail::NEG_HALF * sq_diff);
-    }
-    // General case
-    const double diff = x - mean_;
-    const double sq_diff = diff * diff;
-    return normalizationConstant_ * std::exp(negHalfSigmaSquaredInv_ * sq_diff);
+    bool is_std;
+    double m, norm, neg_half;
+    withCacheSnapshot([&] {
+        is_std = isStandardNormal_;
+        m = mean_;
+        norm = normalizationConstant_;
+        neg_half = negHalfSigmaSquaredInv_;
+    });
+    if (is_std)
+        return detail::INV_SQRT_2PI * std::exp(detail::NEG_HALF * x * x);
+    const double diff = x - m;
+    return norm * std::exp(neg_half * diff * diff);
 }
 
 double GaussianDistribution::getLogProbability(double x) const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_std = isStandardNormal_;
-        const double m = mean_, log_sd = logStandardDeviation_;
-        const double neg_half = negHalfSigmaSquaredInv_;
-        if (is_std)
-            return detail::NEG_HALF_LN_2PI + detail::NEG_HALF * x * x;
-        const double diff = x - m;
-        return detail::NEG_HALF_LN_2PI - log_sd + neg_half * diff * diff;
-    }
-    // Fast path for standard normal
-    if (isStandardNormal_) {
-        const double sq_diff = x * x;
-        return detail::NEG_HALF_LN_2PI + detail::NEG_HALF * sq_diff;
-    }
-    // General case
-    const double diff = x - mean_;
-    const double sq_diff = diff * diff;
-    return detail::NEG_HALF_LN_2PI - logStandardDeviation_ + negHalfSigmaSquaredInv_ * sq_diff;
+    bool is_std;
+    double m, log_sd, neg_half;
+    withCacheSnapshot([&] {
+        is_std = isStandardNormal_;
+        m = mean_;
+        log_sd = logStandardDeviation_;
+        neg_half = negHalfSigmaSquaredInv_;
+    });
+    if (is_std)
+        return detail::NEG_HALF_LN_2PI + detail::NEG_HALF * x * x;
+    const double diff = x - m;
+    return detail::NEG_HALF_LN_2PI - log_sd + neg_half * diff * diff;
 }
 
 double GaussianDistribution::getCumulativeProbability(double x) const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_std = isStandardNormal_;
-        const double m = mean_, sigma_sqrt2 = sigmaSqrt2_;
-        if (is_std)
-            return detail::HALF * (detail::ONE + std::erf(x * detail::INV_SQRT_2));
-        return detail::HALF * (detail::ONE + std::erf((x - m) / sigma_sqrt2));
-    }
-    // Fast path for standard normal
-    if (isStandardNormal_) {
+    bool is_std;
+    double m, sigma_sqrt2;
+    withCacheSnapshot([&] {
+        is_std = isStandardNormal_;
+        m = mean_;
+        sigma_sqrt2 = sigmaSqrt2_;
+    });
+    if (is_std)
         return detail::HALF * (detail::ONE + std::erf(x * detail::INV_SQRT_2));
-    }
-    // General case
-    const double normalized = (x - mean_) / sigmaSqrt2_;
-    return detail::HALF * (detail::ONE + std::erf(normalized));
+    return detail::HALF * (detail::ONE + std::erf((x - m) / sigma_sqrt2));
 }
 
 double GaussianDistribution::getQuantile(double p) const {
@@ -344,22 +309,11 @@ double GaussianDistribution::getQuantile(double p) const {
 }
 
 double GaussianDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double cached_mean, cached_sigma;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_mean = mean_;
-            cached_sigma = standardDeviation_;
-        } else {
-            cached_mean = mean_;
-            cached_sigma = standardDeviation_;
-        }
-    }
+    withCacheSnapshot([&] {
+        cached_mean = mean_;
+        cached_sigma = standardDeviation_;
+    });
 
     // Optimized Box-Muller transform with enhanced numerical stability
     static thread_local bool has_spare = false;

--- a/src/laplace.cpp
+++ b/src/laplace.cpp
@@ -218,18 +218,13 @@ double LaplaceDistribution::getProbability(double x) const {
     if (!std::isfinite(x))
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double m = mu_, nib = neg_inv_b_, nlb = neg_log2b_;
-        return std::exp(nlb + nib * std::fabs(x - m));
-    }
-    // PDF = exp(LogPDF) = exp(neg_log2b_ - |x-mu_|/b_)
-    return std::exp(neg_log2b_ + neg_inv_b_ * std::fabs(x - mu_));
+    double m, nib, nlb;
+    withCacheSnapshot([&] {
+        m = mu_;
+        nib = neg_inv_b_;
+        nlb = neg_log2b_;
+    });
+    return std::exp(nlb + nib * std::fabs(x - m));
 }
 
 double LaplaceDistribution::getLogProbability(double x) const {
@@ -238,18 +233,13 @@ double LaplaceDistribution::getLogProbability(double x) const {
     if (!std::isfinite(x))
         return detail::NEGATIVE_INFINITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double m = mu_, nib = neg_inv_b_, nlb = neg_log2b_;
-        return nlb + nib * std::fabs(x - m);
-    }
-    // LogPDF = neg_log2b_ + neg_inv_b_ * |x - mu_|
-    return neg_log2b_ + neg_inv_b_ * std::fabs(x - mu_);
+    double m, nib, nlb;
+    withCacheSnapshot([&] {
+        m = mu_;
+        nib = neg_inv_b_;
+        nlb = neg_log2b_;
+    });
+    return nlb + nib * std::fabs(x - m);
 }
 
 double LaplaceDistribution::getCumulativeProbability(double x) const {
@@ -258,26 +248,14 @@ double LaplaceDistribution::getCumulativeProbability(double x) const {
     if (!std::isfinite(x))
         return (x > 0) ? detail::ONE : detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double m = mu_, bv = b_;
-        const double d = x - m;
-        return (d <= detail::ZERO_DOUBLE) ? detail::HALF * std::exp(d / bv)
-                                          : detail::ONE - detail::HALF * std::exp(-d / bv);
-    }
-    const double d = x - mu_;
-    if (d <= detail::ZERO_DOUBLE) {
-        // x <= mu: CDF = 0.5 * exp((x-mu)/b) = 0.5 * exp(d/b)
-        return detail::HALF * std::exp(d / b_);
-    } else {
-        // x > mu: CDF = 1 - 0.5 * exp(-(x-mu)/b) = 1 - 0.5 * exp(-d/b)
-        return detail::ONE - detail::HALF * std::exp(-d / b_);
-    }
+    double m, bv;
+    withCacheSnapshot([&] {
+        m = mu_;
+        bv = b_;
+    });
+    const double d = x - m;
+    return (d <= detail::ZERO_DOUBLE) ? detail::HALF * std::exp(d / bv)
+                                      : detail::ONE - detail::HALF * std::exp(-d / bv);
 }
 
 double LaplaceDistribution::getQuantile(double p) const {
@@ -288,80 +266,38 @@ double LaplaceDistribution::getQuantile(double p) const {
     if (p == detail::ONE)
         return std::numeric_limits<double>::infinity();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double m = mu_, bv = b_;
-        if (p == detail::HALF)
-            return m;
-        return (p < detail::HALF) ? m + bv * std::log(detail::TWO * p)
-                                  : m - bv * std::log(detail::TWO * (detail::ONE - p));
-    }
+    double m, bv;
+    withCacheSnapshot([&] {
+        m = mu_;
+        bv = b_;
+    });
     if (p == detail::HALF)
-        return mu_;
-    // Quantile: mu + b * sign(p-0.5) * log(1 - 2|p-0.5|)
-    // For p < 0.5: mu + b * log(2p)
-    // For p > 0.5: mu - b * log(2*(1-p))
-    if (p < detail::HALF) {
-        return mu_ + b_ * std::log(detail::TWO * p);
-    } else {
-        return mu_ - b_ * std::log(detail::TWO * (detail::ONE - p));
-    }
+        return m;
+    return (p < detail::HALF) ? m + bv * std::log(detail::TWO * p)
+                              : m - bv * std::log(detail::TWO * (detail::ONE - p));
 }
 
 double LaplaceDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double m, bv;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            m = mu_;
-            bv = b_;
-        } else {
-            m = mu_;
-            bv = b_;
-        }
-    }
-
-    // Inverse CDF method: U ~ Uniform(0,1), return quantile(U)
+    withCacheSnapshot([&] {
+        m = mu_;
+        bv = b_;
+    });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
     const double u = uniform(rng);
-    if (u < detail::HALF) {
-        return m + bv * std::log(detail::TWO * u);
-    } else {
-        return m - bv * std::log(detail::TWO * (detail::ONE - u));
-    }
+    return (u < detail::HALF) ? m + bv * std::log(detail::TWO * u)
+                              : m - bv * std::log(detail::TWO * (detail::ONE - u));
 }
 
 std::vector<double> LaplaceDistribution::sample(std::mt19937& rng, size_t n) const {
     std::vector<double> samples;
     samples.reserve(n);
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double m, bv;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            m = mu_;
-            bv = b_;
-        } else {
-            m = mu_;
-            bv = b_;
-        }
-    }
-
+    withCacheSnapshot([&] {
+        m = mu_;
+        bv = b_;
+    });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
     for (size_t i = 0; i < n; ++i) {
         const double u = uniform(rng);
@@ -445,18 +381,9 @@ std::string LaplaceDistribution::toString() const {
 //==============================================================================
 
 double LaplaceDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double nlb = neg_log2b_;
-        return detail::ONE - nlb;
-    }
-    // H = 1 + log(2b) = 1 - neg_log2b_
-    return detail::ONE - neg_log2b_;
+    double nlb;
+    withCacheSnapshot([&] { nlb = neg_log2b_; });
+    return detail::ONE - nlb;
 }
 
 //==============================================================================
@@ -471,20 +398,12 @@ void LaplaceDistribution::getProbability(std::span<const double> values, std::sp
         [](const LaplaceDistribution& d, double x) { return d.getProbability(x); },
         // SIMD vectorised batch
         [](const LaplaceDistribution& d, const double* vals, double* res, std::size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double m = d.mu_, nib = d.neg_inv_b_, nlb = d.neg_log2b_;
-                d.getProbabilityBatchUnsafeImpl(vals, res, count, m, nib, nlb);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double m = d.mu_, nib = d.neg_inv_b_, nlb = d.neg_log2b_;
-            lock.unlock();
+            double m, nib, nlb;
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                nib = d.neg_inv_b_;
+                nlb = d.neg_log2b_;
+            });
             d.getProbabilityBatchUnsafeImpl(vals, res, count, m, nib, nlb);
         },
         // Parallel fallback
@@ -494,24 +413,12 @@ void LaplaceDistribution::getProbability(std::span<const double> values, std::sp
             const std::size_t count = vals.size();
             if (count == 0)
                 return;
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double m, nib, nlb;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                } else {
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                nib = d.neg_inv_b_;
+                nlb = d.neg_log2b_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -530,24 +437,12 @@ void LaplaceDistribution::getProbability(std::span<const double> values, std::sp
         [](const LaplaceDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double m, nib, nlb;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                } else {
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                nib = d.neg_inv_b_;
+                nlb = d.neg_log2b_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] =
@@ -564,20 +459,12 @@ void LaplaceDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const LaplaceDistribution& d, double x) { return d.getLogProbability(x); },
         [](const LaplaceDistribution& d, const double* vals, double* res, std::size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double m = d.mu_, nib = d.neg_inv_b_, nlb = d.neg_log2b_;
-                d.getLogProbabilityBatchUnsafeImpl(vals, res, count, m, nib, nlb);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double m = d.mu_, nib = d.neg_inv_b_, nlb = d.neg_log2b_;
-            lock.unlock();
+            double m, nib, nlb;
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                nib = d.neg_inv_b_;
+                nlb = d.neg_log2b_;
+            });
             d.getLogProbabilityBatchUnsafeImpl(vals, res, count, m, nib, nlb);
         },
         [](const LaplaceDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -586,24 +473,12 @@ void LaplaceDistribution::getLogProbability(std::span<const double> values,
             const std::size_t count = vals.size();
             if (count == 0)
                 return;
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double m, nib, nlb;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                } else {
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                nib = d.neg_inv_b_;
+                nlb = d.neg_log2b_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -621,24 +496,12 @@ void LaplaceDistribution::getLogProbability(std::span<const double> values,
         [](const LaplaceDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double m, nib, nlb;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                } else {
-                    m = d.mu_;
-                    nib = d.neg_inv_b_;
-                    nlb = d.neg_log2b_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                nib = d.neg_inv_b_;
+                nlb = d.neg_log2b_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] =
@@ -655,20 +518,11 @@ void LaplaceDistribution::getCumulativeProbability(std::span<const double> value
         *this, values, results, hint, detail::OperationType::CDF,
         [](const LaplaceDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const LaplaceDistribution& d, const double* vals, double* res, std::size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double m = d.mu_, hib = d.half_inv_b_;
-                d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, m, hib);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double m = d.mu_, hib = d.half_inv_b_;
-            lock.unlock();
+            double m, hib;
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                hib = d.half_inv_b_;
+            });
             d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, m, hib);
         },
         [](const LaplaceDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -677,23 +531,12 @@ void LaplaceDistribution::getCumulativeProbability(std::span<const double> value
             const std::size_t count = vals.size();
             if (count == 0)
                 return;
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double m, hib;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    m = d.mu_;
-                    hib = d.half_inv_b_;
-                } else {
-                    m = d.mu_;
-                    hib = d.half_inv_b_;
-                }
-            }
-            const double inv_b = detail::TWO * hib;  // 1/b = 2*(0.5/b)
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                hib = d.half_inv_b_;
+            });
+            const double inv_b = detail::TWO * hib;
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -723,22 +566,11 @@ void LaplaceDistribution::getCumulativeProbability(std::span<const double> value
         [](const LaplaceDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double m, hib;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    m = d.mu_;
-                    hib = d.half_inv_b_;
-                } else {
-                    m = d.mu_;
-                    hib = d.half_inv_b_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                m = d.mu_;
+                hib = d.half_inv_b_;
+            });
             const double inv_b = detail::TWO * hib;
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];

--- a/src/lognormal.cpp
+++ b/src/lognormal.cpp
@@ -165,56 +165,28 @@ void LogNormalDistribution::setParameters(double mu, double sigma) {
 }
 
 double LogNormalDistribution::getMean() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return mean_;  // snapshot while unique_lock still held — no TOCTOU gap
-    }
-    return mean_;
+    double m;
+    withCacheSnapshot([&] { m = mean_; });
+    return m;
 }
 
 double LogNormalDistribution::getVariance() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return variance_;  // snapshot while unique_lock still held — no TOCTOU gap
-    }
-    return variance_;
+    double v;
+    withCacheSnapshot([&] { v = variance_; });
+    return v;
 }
 
 double LogNormalDistribution::getSkewness() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        const double sigma = sigma_;  // snapshot while unique_lock still held
-        const double esigma2 = std::exp(sigma * sigma);
-        return (esigma2 + detail::TWO) * std::sqrt(esigma2 - detail::ONE);
-    }
-    const double esigma2 = std::exp(sigma_ * sigma_);
+    double sigma;
+    withCacheSnapshot([&] { sigma = sigma_; });
+    const double esigma2 = std::exp(sigma * sigma);
     return (esigma2 + detail::TWO) * std::sqrt(esigma2 - detail::ONE);
 }
 
 double LogNormalDistribution::getKurtosis() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        const double s2 = sigma_ * sigma_;  // snapshot while unique_lock still held
-        return std::exp(detail::FOUR * s2) + detail::TWO * std::exp(detail::THREE * s2) +
-               detail::THREE * std::exp(detail::TWO * s2) - detail::SIX;
-    }
-    const double s2 = sigma_ * sigma_;
+    double sigma;
+    withCacheSnapshot([&] { sigma = sigma_; });
+    const double s2 = sigma * sigma;
     return std::exp(detail::FOUR * s2) + detail::TWO * std::exp(detail::THREE * s2) +
            detail::THREE * std::exp(detail::TWO * s2) - detail::SIX;
 }
@@ -278,69 +250,41 @@ double LogNormalDistribution::getProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double mu = mu_;
-        const double neg_inv_2sigma2 = negInv2SigmaSquared_;
-        const double lnc = logNormConst_;
-        const double log_x = std::log(x);
-        const double z = log_x - mu;
-        return std::exp(neg_inv_2sigma2 * z * z - log_x + lnc);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    const double mu = mu_;
-    const double neg_inv_2sigma2 = negInv2SigmaSquared_;
-    const double lnc = logNormConst_;
-    lock.unlock();
+    double mu, ni2s2, lnc;
+    withCacheSnapshot([&] {
+        mu = mu_;
+        ni2s2 = negInv2SigmaSquared_;
+        lnc = logNormConst_;
+    });
     const double log_x = std::log(x);
     const double z = log_x - mu;
-    return std::exp(neg_inv_2sigma2 * z * z - log_x + lnc);
+    return std::exp(ni2s2 * z * z - log_x + lnc);
 }
 
 double LogNormalDistribution::getLogProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::NEGATIVE_INFINITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double mu = mu_;
-        const double neg_inv_2sigma2 = negInv2SigmaSquared_;
-        const double lnc = logNormConst_;
-        const double z = std::log(x) - mu;
-        return neg_inv_2sigma2 * z * z - std::log(x) + lnc;
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    const double z = std::log(x) - mu_;
-    return negInv2SigmaSquared_ * z * z - std::log(x) + logNormConst_;
+    double mu, ni2s2, lnc;
+    withCacheSnapshot([&] {
+        mu = mu_;
+        ni2s2 = negInv2SigmaSquared_;
+        lnc = logNormConst_;
+    });
+    const double z = std::log(x) - mu;
+    return ni2s2 * z * z - std::log(x) + lnc;
 }
 
 double LogNormalDistribution::getCumulativeProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double mu = mu_;
-        const double sigma = sigma_;
-        return detail::normal_cdf((std::log(x) - mu) / sigma);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    return detail::normal_cdf((std::log(x) - mu_) / sigma_);
+    double mu, sigma;
+    withCacheSnapshot([&] {
+        mu = mu_;
+        sigma = sigma_;
+    });
+    return detail::normal_cdf((std::log(x) - mu) / sigma);
 }
 
 double LogNormalDistribution::getQuantile(double p) const {
@@ -352,37 +296,20 @@ double LogNormalDistribution::getQuantile(double p) const {
     if (p == detail::ONE)
         return std::numeric_limits<double>::infinity();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double mu = mu_;
-        const double sigma = sigma_;
-        return std::exp(mu + sigma * detail::inverse_normal_cdf(p));
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    return std::exp(mu_ + sigma_ * detail::inverse_normal_cdf(p));
+    double mu, sigma;
+    withCacheSnapshot([&] {
+        mu = mu_;
+        sigma = sigma_;
+    });
+    return std::exp(mu + sigma * detail::inverse_normal_cdf(p));
 }
 
 double LogNormalDistribution::sample(std::mt19937& rng) const {
     double cached_mu, cached_sigma;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_mu = mu_;  // snapshot while unique_lock still held
-            cached_sigma = sigma_;
-        } else {
-            cached_mu = mu_;  // snapshot while shared_lock still held
-            cached_sigma = sigma_;
-        }
-    }
+    withCacheSnapshot([&] {
+        cached_mu = mu_;
+        cached_sigma = sigma_;
+    });
     std::normal_distribution<double> norm(cached_mu, cached_sigma);
     return std::exp(norm(rng));
 }
@@ -392,21 +319,10 @@ std::vector<double> LogNormalDistribution::sample(std::mt19937& rng, size_t n) c
     samples.reserve(n);
 
     double cached_mu, cached_sigma;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_mu = mu_;  // snapshot while unique_lock still held
-            cached_sigma = sigma_;
-        } else {
-            cached_mu = mu_;  // snapshot while shared_lock still held
-            cached_sigma = sigma_;
-        }
-    }
-
+    withCacheSnapshot([&] {
+        cached_mu = mu_;
+        cached_sigma = sigma_;
+    });
     std::normal_distribution<double> norm(cached_mu, cached_sigma);
     for (size_t i = 0; i < n; ++i) {
         samples.push_back(std::exp(norm(rng)));
@@ -488,17 +404,12 @@ double LogNormalDistribution::getSigmaAtomic() const noexcept {
 }
 
 double LogNormalDistribution::getMode() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        const double mu = mu_;  // snapshot while unique_lock still held
-        const double sigma = sigma_;
-        return std::exp(mu - sigma * sigma);
-    }
-    return std::exp(mu_ - sigma_ * sigma_);
+    double mu, sigma;
+    withCacheSnapshot([&] {
+        mu = mu_;
+        sigma = sigma_;
+    });
+    return std::exp(mu - sigma * sigma);
 }
 
 double LogNormalDistribution::getMedian() const {
@@ -507,18 +418,12 @@ double LogNormalDistribution::getMedian() const {
 }
 
 double LogNormalDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        // H = log(σ) + μ + ½(1 + log(2π))
-        return logSigma_ + mu_ + detail::HALF * (detail::ONE + detail::LN_2PI);
-    }
-    // H = log(σ) + μ + ½(1 + log(2π))
-    return logSigma_ + mu_ + detail::HALF * (detail::ONE + detail::LN_2PI);
+    double ls, mu;
+    withCacheSnapshot([&] {
+        ls = logSigma_;
+        mu = mu_;
+    });
+    return ls + mu + detail::HALF * (detail::ONE + detail::LN_2PI);
 }
 
 //==============================================================================
@@ -532,26 +437,13 @@ void LogNormalDistribution::getProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::PDF,
         [](const LogNormalDistribution& d, double x) { return d.getProbability(x); },
         [](const LogNormalDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — no TOCTOU gap.
-                const double mu = d.mu_;
-                const double neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                const double log_norm_const = d.logNormConst_;
-                d.getProbabilityBatchUnsafeImpl(vals, res, count, mu, neg_inv_2sigma2,
-                                                log_norm_const);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double mu = d.mu_;
-            const double neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-            const double log_norm_const = d.logNormConst_;
-            lock.unlock();
-            d.getProbabilityBatchUnsafeImpl(vals, res, count, mu, neg_inv_2sigma2, log_norm_const);
+            double mu, ni2s2, lnc;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                ni2s2 = d.negInv2SigmaSquared_;
+                lnc = d.logNormConst_;
+            });
+            d.getProbabilityBatchUnsafeImpl(vals, res, count, mu, ni2s2, lnc);
         },
         [](const LogNormalDistribution& d, std::span<const double> vals, std::span<double> res) {
             if (vals.size() != res.size())
@@ -560,24 +452,12 @@ void LogNormalDistribution::getProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            double mu, neg_inv_2sigma2, log_norm_const;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    mu = d.mu_;  // snapshot while unique_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                } else {
-                    mu = d.mu_;  // snapshot while shared_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                }
-            }
-
+            double mu, ni2s2, lnc;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                ni2s2 = d.negInv2SigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -586,7 +466,7 @@ void LogNormalDistribution::getProbability(std::span<const double> values,
                     } else {
                         const double log_x = std::log(x);
                         const double z = log_x - mu;
-                        res[i] = std::exp(neg_inv_2sigma2 * z * z - log_x + log_norm_const);
+                        res[i] = std::exp(ni2s2 * z * z - log_x + lnc);
                     }
                 });
             } else {
@@ -597,7 +477,7 @@ void LogNormalDistribution::getProbability(std::span<const double> values,
                     } else {
                         const double log_x = std::log(x);
                         const double z = log_x - mu;
-                        res[i] = std::exp(neg_inv_2sigma2 * z * z - log_x + log_norm_const);
+                        res[i] = std::exp(ni2s2 * z * z - log_x + lnc);
                     }
                 }
             }
@@ -610,24 +490,12 @@ void LogNormalDistribution::getProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            double mu, neg_inv_2sigma2, log_norm_const;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    mu = d.mu_;  // snapshot while unique_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                } else {
-                    mu = d.mu_;  // snapshot while shared_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                }
-            }
-
+            double mu, ni2s2, lnc;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                ni2s2 = d.negInv2SigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 if (x <= detail::ZERO_DOUBLE) {
@@ -635,7 +503,7 @@ void LogNormalDistribution::getProbability(std::span<const double> values,
                 } else {
                     const double log_x = std::log(x);
                     const double z = log_x - mu;
-                    res[i] = std::exp(neg_inv_2sigma2 * z * z - log_x + log_norm_const);
+                    res[i] = std::exp(ni2s2 * z * z - log_x + lnc);
                 }
             });
             pool.waitForAll();
@@ -649,27 +517,13 @@ void LogNormalDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const LogNormalDistribution& d, double x) { return d.getLogProbability(x); },
         [](const LogNormalDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — no TOCTOU gap.
-                const double mu = d.mu_;
-                const double neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                const double log_norm_const = d.logNormConst_;
-                d.getLogProbabilityBatchUnsafeImpl(vals, res, count, mu, neg_inv_2sigma2,
-                                                   log_norm_const);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double mu = d.mu_;
-            const double neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-            const double log_norm_const = d.logNormConst_;
-            lock.unlock();
-            d.getLogProbabilityBatchUnsafeImpl(vals, res, count, mu, neg_inv_2sigma2,
-                                               log_norm_const);
+            double mu, ni2s2, lnc;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                ni2s2 = d.negInv2SigmaSquared_;
+                lnc = d.logNormConst_;
+            });
+            d.getLogProbabilityBatchUnsafeImpl(vals, res, count, mu, ni2s2, lnc);
         },
         [](const LogNormalDistribution& d, std::span<const double> vals, std::span<double> res) {
             if (vals.size() != res.size())
@@ -678,24 +532,12 @@ void LogNormalDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            double mu, neg_inv_2sigma2, log_norm_const;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    mu = d.mu_;  // snapshot while unique_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                } else {
-                    mu = d.mu_;  // snapshot while shared_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                }
-            }
-
+            double mu, ni2s2, lnc;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                ni2s2 = d.negInv2SigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -704,7 +546,7 @@ void LogNormalDistribution::getLogProbability(std::span<const double> values,
                     } else {
                         const double log_x = std::log(x);
                         const double z = log_x - mu;
-                        res[i] = neg_inv_2sigma2 * z * z - log_x + log_norm_const;
+                        res[i] = ni2s2 * z * z - log_x + lnc;
                     }
                 });
             } else {
@@ -715,7 +557,7 @@ void LogNormalDistribution::getLogProbability(std::span<const double> values,
                     } else {
                         const double log_x = std::log(x);
                         const double z = log_x - mu;
-                        res[i] = neg_inv_2sigma2 * z * z - log_x + log_norm_const;
+                        res[i] = ni2s2 * z * z - log_x + lnc;
                     }
                 }
             }
@@ -728,24 +570,12 @@ void LogNormalDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
 
-            double mu, neg_inv_2sigma2, log_norm_const;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    mu = d.mu_;  // snapshot while unique_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                } else {
-                    mu = d.mu_;  // snapshot while shared_lock still held
-                    neg_inv_2sigma2 = d.negInv2SigmaSquared_;
-                    log_norm_const = d.logNormConst_;
-                }
-            }
-
+            double mu, ni2s2, lnc;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                ni2s2 = d.negInv2SigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 if (x <= detail::ZERO_DOUBLE) {
@@ -753,7 +583,7 @@ void LogNormalDistribution::getLogProbability(std::span<const double> values,
                 } else {
                     const double log_x = std::log(x);
                     const double z = log_x - mu;
-                    res[i] = neg_inv_2sigma2 * z * z - log_x + log_norm_const;
+                    res[i] = ni2s2 * z * z - log_x + lnc;
                 }
             });
             pool.waitForAll();
@@ -767,23 +597,12 @@ void LogNormalDistribution::getCumulativeProbability(std::span<const double> val
         *this, values, results, hint, detail::OperationType::CDF,
         [](const LogNormalDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const LogNormalDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — no TOCTOU gap.
-                const double mu = d.mu_;
-                const double inv_sigma_sqrt2 = d.invSigmaSqrt2_;
-                d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, mu, inv_sigma_sqrt2);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double mu = d.mu_;
-            const double inv_sigma_sqrt2 = d.invSigmaSqrt2_;
-            lock.unlock();
-            d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, mu, inv_sigma_sqrt2);
+            double mu, iss2;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                iss2 = d.invSigmaSqrt2_;
+            });
+            d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, mu, iss2);
         },
         [](const LogNormalDistribution& d, std::span<const double> vals, std::span<double> res) {
             if (vals.size() != res.size())
@@ -792,36 +611,22 @@ void LogNormalDistribution::getCumulativeProbability(std::span<const double> val
             if (count == 0)
                 return;
 
-            double mu, inv_sigma_sqrt2;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    mu = d.mu_;  // snapshot while unique_lock still held
-                    inv_sigma_sqrt2 = d.invSigmaSqrt2_;
-                } else {
-                    mu = d.mu_;  // snapshot while shared_lock still held
-                    inv_sigma_sqrt2 = d.invSigmaSqrt2_;
-                }
-            }
-
-            // Chunk so each task runs the vector_erf SIMD pipeline rather than
-            // calling scalar detail::normal_cdf per element.
+            double mu, iss2;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                iss2 = d.invSigmaSqrt2_;
+            });
             constexpr std::size_t CHUNK = 1024;
             if (arch::should_use_parallel(count)) {
                 const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
                 ParallelUtils::parallelFor(std::size_t{0}, num_chunks, [&](std::size_t ci) {
                     const std::size_t start = ci * CHUNK;
                     const std::size_t len = std::min(CHUNK, count - start);
-                    d.getCumulativeProbabilityBatchUnsafeImpl(
-                        vals.data() + start, res.data() + start, len, mu, inv_sigma_sqrt2);
+                    d.getCumulativeProbabilityBatchUnsafeImpl(vals.data() + start,
+                                                              res.data() + start, len, mu, iss2);
                 });
             } else {
-                d.getCumulativeProbabilityBatchUnsafeImpl(vals.data(), res.data(), count, mu,
-                                                          inv_sigma_sqrt2);
+                d.getCumulativeProbabilityBatchUnsafeImpl(vals.data(), res.data(), count, mu, iss2);
             }
         },
         [](const LogNormalDistribution& d, std::span<const double> vals, std::span<double> res,
@@ -832,29 +637,18 @@ void LogNormalDistribution::getCumulativeProbability(std::span<const double> val
             if (count == 0)
                 return;
 
-            double mu, inv_sigma_sqrt2;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    mu = d.mu_;  // snapshot while unique_lock still held
-                    inv_sigma_sqrt2 = d.invSigmaSqrt2_;
-                } else {
-                    mu = d.mu_;  // snapshot while shared_lock still held
-                    inv_sigma_sqrt2 = d.invSigmaSqrt2_;
-                }
-            }
-
+            double mu, iss2;
+            d.withCacheSnapshot([&] {
+                mu = d.mu_;
+                iss2 = d.invSigmaSqrt2_;
+            });
             constexpr std::size_t CHUNK = 1024;
             const std::size_t num_chunks = (count + CHUNK - 1) / CHUNK;
             pool.parallelFor(std::size_t{0}, num_chunks, [&](std::size_t ci) {
                 const std::size_t start = ci * CHUNK;
                 const std::size_t len = std::min(CHUNK, count - start);
                 d.getCumulativeProbabilityBatchUnsafeImpl(vals.data() + start, res.data() + start,
-                                                          len, mu, inv_sigma_sqrt2);
+                                                          len, mu, iss2);
             });
             pool.waitForAll();
         });

--- a/src/negative_binomial.cpp
+++ b/src/negative_binomial.cpp
@@ -245,28 +245,20 @@ double NegativeBinomialDistribution::getProbability(double x) const {
     if (k < 0)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double sp = p_, sr = r_, slgr = logGammaR_, slp = logP_, sl1mp = log1mP_;
-        if (sp >= detail::ONE)
-            return (k == 0) ? detail::ONE : detail::ZERO_DOUBLE;
-        const double lp_val = std::lgamma(static_cast<double>(k) + sr) -
-                              std::lgamma(static_cast<double>(k + 1)) - slgr + sr * slp +
-                              static_cast<double>(k) * sl1mp;
-        return std::clamp(std::exp(lp_val), detail::ZERO_DOUBLE, detail::ONE);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    if (p_ >= detail::ONE)
+    double sp, sr, slgr, slp, sl1mp;
+    withCacheSnapshot([&] {
+        sp = p_;
+        sr = r_;
+        slgr = logGammaR_;
+        slp = logP_;
+        sl1mp = log1mP_;
+    });
+    if (sp >= detail::ONE)
         return (k == 0) ? detail::ONE : detail::ZERO_DOUBLE;
-    const double lp = std::lgamma(static_cast<double>(k) + r_) -
-                      std::lgamma(static_cast<double>(k + 1)) - logGammaR_ + r_ * logP_ +
-                      static_cast<double>(k) * log1mP_;
-    return std::clamp(std::exp(lp), detail::ZERO_DOUBLE, detail::ONE);
+    const double lp_val = std::lgamma(static_cast<double>(k) + sr) -
+                          std::lgamma(static_cast<double>(k + 1)) - slgr + sr * slp +
+                          static_cast<double>(k) * sl1mp;
+    return std::clamp(std::exp(lp_val), detail::ZERO_DOUBLE, detail::ONE);
 }
 
 double NegativeBinomialDistribution::getLogProbability(double x) const {
@@ -278,24 +270,18 @@ double NegativeBinomialDistribution::getLogProbability(double x) const {
     if (k < 0)
         return detail::NEGATIVE_INFINITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double sp = p_, sr = r_, slgr = logGammaR_, slp = logP_, sl1mp = log1mP_;
-        if (sp >= detail::ONE)
-            return (k == 0) ? detail::ZERO_DOUBLE : detail::NEGATIVE_INFINITY;
-        return std::lgamma(static_cast<double>(k) + sr) - std::lgamma(static_cast<double>(k + 1)) -
-               slgr + sr * slp + static_cast<double>(k) * sl1mp;
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    if (p_ >= detail::ONE)
+    double sp, sr, slgr, slp, sl1mp;
+    withCacheSnapshot([&] {
+        sp = p_;
+        sr = r_;
+        slgr = logGammaR_;
+        slp = logP_;
+        sl1mp = log1mP_;
+    });
+    if (sp >= detail::ONE)
         return (k == 0) ? detail::ZERO_DOUBLE : detail::NEGATIVE_INFINITY;
-    return std::lgamma(static_cast<double>(k) + r_) - std::lgamma(static_cast<double>(k + 1)) -
-           logGammaR_ + r_ * logP_ + static_cast<double>(k) * log1mP_;
+    return std::lgamma(static_cast<double>(k) + sr) - std::lgamma(static_cast<double>(k + 1)) -
+           slgr + sr * slp + static_cast<double>(k) * sl1mp;
 }
 
 double NegativeBinomialDistribution::getCumulativeProbability(double x) const {
@@ -309,18 +295,12 @@ double NegativeBinomialDistribution::getCumulativeProbability(double x) const {
     if (k < 0)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double sp = p_, sr = r_;
-        return detail::beta_i(sp, sr, static_cast<double>(k + 1));
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    return detail::beta_i(p_, r_, static_cast<double>(k + 1));
+    double sp, sr;
+    withCacheSnapshot([&] {
+        sp = p_;
+        sr = r_;
+    });
+    return detail::beta_i(sp, sr, static_cast<double>(k + 1));
 }
 
 double NegativeBinomialDistribution::getQuantile(double prob) const {
@@ -530,21 +510,12 @@ double NegativeBinomialDistribution::getMode() const {
 }
 
 double NegativeBinomialDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double sr = r_, sp = p_;
-        const double var = sr * (detail::ONE - sp) / (sp * sp);
-        if (var <= detail::ZERO)
-            return detail::ZERO_DOUBLE;
-        return detail::HALF * std::log(detail::TWO * detail::PI * detail::E * var);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    const double var = r_ * (detail::ONE - p_) / (p_ * p_);
+    double sr, sp;
+    withCacheSnapshot([&] {
+        sr = r_;
+        sp = p_;
+    });
+    const double var = sr * (detail::ONE - sp) / (sp * sp);
     if (var <= detail::ZERO)
         return detail::ZERO_DOUBLE;
     return detail::HALF * std::log(detail::TWO * detail::PI * detail::E * var);
@@ -561,20 +532,13 @@ void NegativeBinomialDistribution::getProbability(std::span<const double> values
         *this, values, results, hint, detail::OperationType::PDF,
         [](const NegativeBinomialDistribution& d, double x) { return d.getProbability(x); },
         [](const NegativeBinomialDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double r = d.r_, lgr = d.logGammaR_, lp = d.logP_, l1mp = d.log1mP_;
-                d.getProbabilityBatchImpl(vals, res, count, r, lgr, lp, l1mp);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double r = d.r_, lgr = d.logGammaR_, lp = d.logP_, l1mp = d.log1mP_;
-            lock.unlock();
+            double r, lgr, lp, l1mp;
+            d.withCacheSnapshot([&] {
+                r = d.r_;
+                lgr = d.logGammaR_;
+                lp = d.logP_;
+                l1mp = d.log1mP_;
+            });
             d.getProbabilityBatchImpl(vals, res, count, r, lgr, lp, l1mp);
         },
         [](const NegativeBinomialDistribution& d, std::span<const double> vals,
@@ -609,20 +573,13 @@ void NegativeBinomialDistribution::getLogProbability(std::span<const double> val
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const NegativeBinomialDistribution& d, double x) { return d.getLogProbability(x); },
         [](const NegativeBinomialDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double r = d.r_, lgr = d.logGammaR_, lp = d.logP_, l1mp = d.log1mP_;
-                d.getLogProbabilityBatchImpl(vals, res, count, r, lgr, lp, l1mp);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double r = d.r_, lgr = d.logGammaR_, lp = d.logP_, l1mp = d.log1mP_;
-            lock.unlock();
+            double r, lgr, lp, l1mp;
+            d.withCacheSnapshot([&] {
+                r = d.r_;
+                lgr = d.logGammaR_;
+                lp = d.logP_;
+                l1mp = d.log1mP_;
+            });
             d.getLogProbabilityBatchImpl(vals, res, count, r, lgr, lp, l1mp);
         },
         [](const NegativeBinomialDistribution& d, std::span<const double> vals,

--- a/src/pareto.cpp
+++ b/src/pareto.cpp
@@ -166,71 +166,35 @@ void ParetoDistribution::setParameters(double scale, double alpha) {
 }
 
 double ParetoDistribution::getMean() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return mean_;  // snapshot while unique_lock still held — no TOCTOU gap
-    }
-    return mean_;
+    double m;
+    withCacheSnapshot([&] { m = mean_; });
+    return m;
 }
 
 double ParetoDistribution::getVariance() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return variance_;  // snapshot while unique_lock still held — no TOCTOU gap
-    }
-    return variance_;
+    double v;
+    withCacheSnapshot([&] { v = variance_; });
+    return v;
 }
 
 double ParetoDistribution::getSkewness() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        const double alpha = alpha_;  // snapshot while unique_lock still held
-        if (alpha <= detail::THREE)
-            return std::numeric_limits<double>::infinity();
-        return detail::TWO * (detail::ONE + alpha) / (alpha - detail::THREE) *
-               std::sqrt((alpha - detail::TWO) / alpha);
-    }
-    if (alpha_ <= detail::THREE)
+    double alpha;
+    withCacheSnapshot([&] { alpha = alpha_; });
+    if (alpha <= detail::THREE)
         return std::numeric_limits<double>::infinity();
-    // 2(1+α)/(α−3) * sqrt((α−2)/α)
-    return detail::TWO * (detail::ONE + alpha_) / (alpha_ - detail::THREE) *
-           std::sqrt((alpha_ - detail::TWO) / alpha_);
+    return detail::TWO * (detail::ONE + alpha) / (alpha - detail::THREE) *
+           std::sqrt((alpha - detail::TWO) / alpha);
 }
 
 double ParetoDistribution::getKurtosis() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        const double alpha = alpha_;  // snapshot while unique_lock still held
-        if (alpha <= detail::FOUR)
-            return std::numeric_limits<double>::infinity();
-        const double a2 = alpha * alpha;
-        const double a3 = a2 * alpha;
-        return detail::SIX * (a3 + a2 - detail::SIX * alpha - detail::TWO) /
-               (alpha * (alpha - detail::THREE) * (alpha - detail::FOUR));
-    }
-    if (alpha_ <= detail::FOUR)
+    double alpha;
+    withCacheSnapshot([&] { alpha = alpha_; });
+    if (alpha <= detail::FOUR)
         return std::numeric_limits<double>::infinity();
-    // 6(α³+α²−6α−2) / (α(α−3)(α−4))
-    const double a2 = alpha_ * alpha_;
-    const double a3 = a2 * alpha_;
-    return detail::SIX * (a3 + a2 - detail::SIX * alpha_ - detail::TWO) /
-           (alpha_ * (alpha_ - detail::THREE) * (alpha_ - detail::FOUR));
+    const double a2 = alpha * alpha;
+    const double a3 = a2 * alpha;
+    return detail::SIX * (a3 + a2 - detail::SIX * alpha - detail::TWO) /
+           (alpha * (alpha - detail::THREE) * (alpha - detail::FOUR));
 }
 
 //==============================================================================
@@ -287,69 +251,38 @@ VoidResult ParetoDistribution::validateCurrentParameters() const noexcept {
 //==============================================================================
 
 double ParetoDistribution::getProbability(double x) const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double scale = scale_;
-        const double lnc = logNormConst_;
-        const double neg_ap1 = negAlphaPlusOne_;
-        if (x < scale)
-            return detail::ZERO_DOUBLE;
-        return std::exp(lnc + neg_ap1 * std::log(x));
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    if (x < scale_)
+    double scale, lnc, neg_ap1;
+    withCacheSnapshot([&] {
+        scale = scale_;
+        lnc = logNormConst_;
+        neg_ap1 = negAlphaPlusOne_;
+    });
+    if (x < scale)
         return detail::ZERO_DOUBLE;
-    const double lnc = logNormConst_;
-    const double neg_ap1 = negAlphaPlusOne_;
-    lock.unlock();
     return std::exp(lnc + neg_ap1 * std::log(x));
 }
 
 double ParetoDistribution::getLogProbability(double x) const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double scale = scale_;
-        const double lnc = logNormConst_;
-        const double neg_ap1 = negAlphaPlusOne_;
-        if (x < scale)
-            return detail::NEGATIVE_INFINITY;
-        return lnc + neg_ap1 * std::log(x);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    if (x < scale_)
+    double scale, lnc, neg_ap1;
+    withCacheSnapshot([&] {
+        scale = scale_;
+        lnc = logNormConst_;
+        neg_ap1 = negAlphaPlusOne_;
+    });
+    if (x < scale)
         return detail::NEGATIVE_INFINITY;
-    return logNormConst_ + negAlphaPlusOne_ * std::log(x);
+    return lnc + neg_ap1 * std::log(x);
 }
 
 double ParetoDistribution::getCumulativeProbability(double x) const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double scale = scale_;
-        const double alpha = alpha_;
-        if (x < scale)
-            return detail::ZERO_DOUBLE;
-        return detail::ONE - std::pow(scale / x, alpha);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    if (x < scale_)
+    double scale, alpha;
+    withCacheSnapshot([&] {
+        scale = scale_;
+        alpha = alpha_;
+    });
+    if (x < scale)
         return detail::ZERO_DOUBLE;
-    // 1 − (x_m/x)^α = 1 − exp(α·log(x_m/x))
-    return detail::ONE - std::pow(scale_ / x, alpha_);
+    return detail::ONE - std::pow(scale / x, alpha);
 }
 
 double ParetoDistribution::getQuantile(double p) const {
@@ -360,41 +293,22 @@ double ParetoDistribution::getQuantile(double p) const {
         return std::numeric_limits<double>::infinity();
 
     // Acquire lock before reading any member (including the p==0 edge case).
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
+    double scale, inv_alpha;
+    withCacheSnapshot([&] {
+        scale = scale_;
+        inv_alpha = invAlpha_;
+    });
     if (p == detail::ZERO_DOUBLE)
-        return scale_;  // x_m (scale) is the support lower bound
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        const double scale = scale_;
-        const double inv_alpha = invAlpha_;
-        return scale * std::pow(detail::ONE - p, -inv_alpha);
-    }
-    // Cache hit — read directly under shared_lock (no gap possible)
-    // x_m * (1-p)^(-1/α) = x_m / (1-p)^(1/α)
-    return scale_ * std::pow(detail::ONE - p, -invAlpha_);
+        return scale;
+    return scale * std::pow(detail::ONE - p, -inv_alpha);
 }
 
 double ParetoDistribution::sample(std::mt19937& rng) const {
     double cached_scale, cached_inv_alpha;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_scale = scale_;  // snapshot while unique_lock still held
-            cached_inv_alpha = invAlpha_;
-        } else {
-            cached_scale = scale_;  // snapshot while shared_lock still held
-            cached_inv_alpha = invAlpha_;
-        }
-    }
-    // Inverse CDF method: x_m / U^(1/α) where U ~ Uniform(0, 1)
+    withCacheSnapshot([&] {
+        cached_scale = scale_;
+        cached_inv_alpha = invAlpha_;
+    });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
     return cached_scale * std::pow(uniform(rng), -cached_inv_alpha);
 }
@@ -404,21 +318,10 @@ std::vector<double> ParetoDistribution::sample(std::mt19937& rng, size_t n) cons
     samples.reserve(n);
 
     double cached_scale, cached_inv_alpha;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_scale = scale_;  // snapshot while unique_lock still held
-            cached_inv_alpha = invAlpha_;
-        } else {
-            cached_scale = scale_;  // snapshot while shared_lock still held
-            cached_inv_alpha = invAlpha_;
-        }
-    }
-
+    withCacheSnapshot([&] {
+        cached_scale = scale_;
+        cached_inv_alpha = invAlpha_;
+    });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
     for (size_t i = 0; i < n; ++i) {
         samples.push_back(cached_scale * std::pow(uniform(rng), -cached_inv_alpha));
@@ -505,33 +408,22 @@ double ParetoDistribution::getMode() const {
 }
 
 double ParetoDistribution::getMedian() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        const double scale = scale_;  // snapshot while unique_lock still held
-        const double inv_alpha = invAlpha_;
-        return scale * std::exp(detail::LN2 * inv_alpha);
-    }
-    // x_m * 2^(1/α)
-    return scale_ * std::exp(detail::LN2 * invAlpha_);
+    double scale, inv_alpha;
+    withCacheSnapshot([&] {
+        scale = scale_;
+        inv_alpha = invAlpha_;
+    });
+    return scale * std::exp(detail::LN2 * inv_alpha);
 }
 
 double ParetoDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — no TOCTOU gap.
-        // H = log(x_m/α) + 1 + 1/α = log(x_m) - log(α) + 1 + 1/α
-        return logScale_ - logAlpha_ + detail::ONE + invAlpha_;
-    }
-    // H = log(x_m/α) + 1 + 1/α = log(x_m) - log(α) + 1 + 1/α
-    return logScale_ - logAlpha_ + detail::ONE + invAlpha_;
+    double ls, la, ia;
+    withCacheSnapshot([&] {
+        ls = logScale_;
+        la = logAlpha_;
+        ia = invAlpha_;
+    });
+    return ls - la + detail::ONE + ia;
 }
 
 //==============================================================================
@@ -544,20 +436,12 @@ void ParetoDistribution::getProbability(std::span<const double> values, std::spa
         *this, values, results, hint, detail::OperationType::PDF,
         [](const ParetoDistribution& d, double x) { return d.getProbability(x); },
         [](const ParetoDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — no TOCTOU gap.
-                const double scale = d.scale_, neg_ap1 = d.negAlphaPlusOne_, lnc = d.logNormConst_;
-                d.getProbabilityBatchUnsafeImpl(vals, res, count, scale, neg_ap1, lnc);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double scale = d.scale_, neg_ap1 = d.negAlphaPlusOne_, lnc = d.logNormConst_;
-            lock.unlock();
+            double scale, neg_ap1, lnc;
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                neg_ap1 = d.negAlphaPlusOne_;
+                lnc = d.logNormConst_;
+            });
             d.getProbabilityBatchUnsafeImpl(vals, res, count, scale, neg_ap1, lnc);
         },
         [](const ParetoDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -568,23 +452,11 @@ void ParetoDistribution::getProbability(std::span<const double> values, std::spa
                 return;
 
             double scale, lnc, neg_ap1;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                } else {
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                }
-            }
-
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                lnc = d.logNormConst_;
+                neg_ap1 = d.negAlphaPlusOne_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -602,25 +474,12 @@ void ParetoDistribution::getProbability(std::span<const double> values, std::spa
         [](const ParetoDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-
             double scale, lnc, neg_ap1;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                } else {
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                }
-            }
-
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                lnc = d.logNormConst_;
+                neg_ap1 = d.negAlphaPlusOne_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] = (x < scale) ? detail::ZERO_DOUBLE : std::exp(lnc + neg_ap1 * std::log(x));
@@ -636,20 +495,12 @@ void ParetoDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const ParetoDistribution& d, double x) { return d.getLogProbability(x); },
         [](const ParetoDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — no TOCTOU gap.
-                const double scale = d.scale_, neg_ap1 = d.negAlphaPlusOne_, lnc = d.logNormConst_;
-                d.getLogProbabilityBatchUnsafeImpl(vals, res, count, scale, neg_ap1, lnc);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double scale = d.scale_, neg_ap1 = d.negAlphaPlusOne_, lnc = d.logNormConst_;
-            lock.unlock();
+            double scale, neg_ap1, lnc;
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                neg_ap1 = d.negAlphaPlusOne_;
+                lnc = d.logNormConst_;
+            });
             d.getLogProbabilityBatchUnsafeImpl(vals, res, count, scale, neg_ap1, lnc);
         },
         [](const ParetoDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -660,23 +511,11 @@ void ParetoDistribution::getLogProbability(std::span<const double> values,
                 return;
 
             double scale, lnc, neg_ap1;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                } else {
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                }
-            }
-
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                lnc = d.logNormConst_;
+                neg_ap1 = d.negAlphaPlusOne_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -692,25 +531,12 @@ void ParetoDistribution::getLogProbability(std::span<const double> values,
         [](const ParetoDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-
             double scale, lnc, neg_ap1;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                } else {
-                    scale = d.scale_;
-                    lnc = d.logNormConst_;
-                    neg_ap1 = d.negAlphaPlusOne_;
-                }
-            }
-
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                lnc = d.logNormConst_;
+                neg_ap1 = d.negAlphaPlusOne_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] = (x < scale) ? detail::NEGATIVE_INFINITY : lnc + neg_ap1 * std::log(x);
@@ -726,25 +552,12 @@ void ParetoDistribution::getCumulativeProbability(std::span<const double> values
         *this, values, results, hint, detail::OperationType::CDF,
         [](const ParetoDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const ParetoDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — no TOCTOU gap.
-                const double scale = d.scale_;
-                const double log_scale = d.logScale_;
-                const double neg_alpha = d.negAlpha_;
-                d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, scale, log_scale,
-                                                          neg_alpha);
-                return;
-            }
-            // Cache hit — read directly under shared_lock (no gap possible)
-            const double scale = d.scale_;
-            const double log_scale = d.logScale_;
-            const double neg_alpha = d.negAlpha_;
-            lock.unlock();
+            double scale, log_scale, neg_alpha;
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                log_scale = d.logScale_;
+                neg_alpha = d.negAlpha_;
+            });
             d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, scale, log_scale,
                                                       neg_alpha);
         },
@@ -756,21 +569,10 @@ void ParetoDistribution::getCumulativeProbability(std::span<const double> values
                 return;
 
             double scale, alpha;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    scale = d.scale_;
-                    alpha = d.alpha_;
-                } else {
-                    scale = d.scale_;
-                    alpha = d.alpha_;
-                }
-            }
-
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                alpha = d.alpha_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -788,23 +590,11 @@ void ParetoDistribution::getCumulativeProbability(std::span<const double> values
         [](const ParetoDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-
             double scale, alpha;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    scale = d.scale_;
-                    alpha = d.alpha_;
-                } else {
-                    scale = d.scale_;
-                    alpha = d.alpha_;
-                }
-            }
-
+            d.withCacheSnapshot([&] {
+                scale = d.scale_;
+                alpha = d.alpha_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] =

--- a/src/poisson.cpp
+++ b/src/poisson.cpp
@@ -130,31 +130,15 @@ double PoissonDistribution::getVariance() const {
 }
 
 double PoissonDistribution::getSkewness() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double sqrtL = sqrtLambda_;
-        return detail::ONE / sqrtL;
-    }
-    return detail::ONE / sqrtLambda_;  // 1/√λ
+    double sqrtL;
+    withCacheSnapshot([&] { sqrtL = sqrtLambda_; });
+    return detail::ONE / sqrtL;
 }
 
 double PoissonDistribution::getKurtosis() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double invL = invLambda_;
-        return invL;
-    }
-    return invLambda_;  // 1/λ (excess kurtosis)
+    double invL;
+    withCacheSnapshot([&] { invL = invLambda_; });
+    return invL;
 }
 
 double PoissonDistribution::getLambdaAtomic() const noexcept {
@@ -358,27 +342,13 @@ double PoissonDistribution::getQuantile(double p) const {
 }
 
 double PoissonDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
-    double cached_lambda;
+    double cached_lambda, cached_exp_neg_lambda;
     bool cached_is_small;
-    double cached_exp_neg_lambda;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_lambda = lambda_;
-            cached_is_small = isSmallLambda_;
-            cached_exp_neg_lambda = expNegLambda_;
-        } else {
-            cached_lambda = lambda_;
-            cached_is_small = isSmallLambda_;
-            cached_exp_neg_lambda = expNegLambda_;
-        }
-    }
-
+    withCacheSnapshot([&] {
+        cached_lambda = lambda_;
+        cached_is_small = isSmallLambda_;
+        cached_exp_neg_lambda = expNegLambda_;
+    });
     if (cached_is_small) {
         // Knuth's algorithm for small lambda
         double L = cached_exp_neg_lambda;
@@ -406,28 +376,13 @@ std::vector<double> PoissonDistribution::sample(std::mt19937& rng, size_t n) con
     std::vector<double> samples;
     samples.reserve(n);
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
-    double cached_lambda;
+    double cached_lambda, cached_exp_neg_lambda;
     bool cached_is_small;
-    double cached_exp_neg_lambda;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_lambda = lambda_;
-            cached_is_small = isSmallLambda_;
-            cached_exp_neg_lambda = expNegLambda_;
-        } else {
-            cached_lambda = lambda_;
-            cached_is_small = isSmallLambda_;
-            cached_exp_neg_lambda = expNegLambda_;
-        }
-    }
-
-    // Generate batch samples using the appropriate method
+    withCacheSnapshot([&] {
+        cached_lambda = lambda_;
+        cached_is_small = isSmallLambda_;
+        cached_exp_neg_lambda = expNegLambda_;
+    });
     if (cached_is_small) {
         // Knuth's algorithm for small lambda - optimized for batch
         double L = cached_exp_neg_lambda;
@@ -547,32 +502,16 @@ double PoissonDistribution::getProbabilityExact(int k) const {
     if (k < 0)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const bool is_small = isSmallLambda_;
-        return is_small ? computePMFSmall(k) : computePMFLarge(k);
-    }
-    return isSmallLambda_ ? computePMFSmall(k) : computePMFLarge(k);
+    bool is_small;
+    withCacheSnapshot([&] { is_small = isSmallLambda_; });
+    return is_small ? computePMFSmall(k) : computePMFLarge(k);
 }
 
 double PoissonDistribution::getLogProbabilityExact(int k) const noexcept {
     if (k < 0)
         return detail::MIN_LOG_PROBABILITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        return computeLogPMF(k);
-    }
+    withCacheSnapshot([&] {});  // ensure cache valid; computeLogPMF reads cached members
     return computeLogPMF(k);
 }
 
@@ -611,28 +550,13 @@ void PoissonDistribution::getProbability(std::span<const double> values, std::sp
         *this, values, results, hint, detail::OperationType::PDF,
         [](const PoissonDistribution& dist, double value) { return dist.getProbability(value); },
         [](const PoissonDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_)
-                    dist.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double cached_lambda = dist.lambda_;
-                const double cached_log_lambda = dist.logLambda_;
-                const double cached_exp_neg_lambda = dist.expNegLambda_;
-                dist.getProbabilityBatchUnsafeImpl(vals, res, count, cached_lambda,
-                                                   cached_log_lambda, cached_exp_neg_lambda);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double cached_lambda = dist.lambda_;
-            const double cached_log_lambda = dist.logLambda_;
-            const double cached_exp_neg_lambda = dist.expNegLambda_;
-            lock.unlock();
-            // Call private implementation directly
-            dist.getProbabilityBatchUnsafeImpl(vals, res, count, cached_lambda, cached_log_lambda,
-                                               cached_exp_neg_lambda);
+            double lam, loglam, enl;
+            dist.withCacheSnapshot([&] {
+                lam = dist.lambda_;
+                loglam = dist.logLambda_;
+                enl = dist.expNegLambda_;
+            });
+            dist.getProbabilityBatchUnsafeImpl(vals, res, count, lam, loglam, enl);
         },
         [](const PoissonDistribution& dist, std::span<const double> vals, std::span<double> res) {
             // Parallel-SIMD lambda: should use ParallelUtils::parallelFor
@@ -644,29 +568,12 @@ void PoissonDistribution::getProbability(std::span<const double> values, std::sp
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double cached_lambda, cached_log_lambda, cached_exp_neg_lambda;
-            [[maybe_unused]] bool cached_is_small_lambda;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_lambda = dist.lambda_;
-                    cached_log_lambda = dist.logLambda_;
-                    cached_exp_neg_lambda = dist.expNegLambda_;
-                    cached_is_small_lambda = dist.isSmallLambda_;
-                } else {
-                    cached_lambda = dist.lambda_;
-                    cached_log_lambda = dist.logLambda_;
-                    cached_exp_neg_lambda = dist.expNegLambda_;
-                    cached_is_small_lambda = dist.isSmallLambda_;
-                }
-            }
-
-            // Use ParallelUtils::parallelFor for Level 0-3 integration
+            dist.withCacheSnapshot([&] {
+                cached_lambda = dist.lambda_;
+                cached_log_lambda = dist.logLambda_;
+                cached_exp_neg_lambda = dist.expNegLambda_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     if (vals[i] < detail::ZERO_DOUBLE) {
@@ -732,29 +639,12 @@ void PoissonDistribution::getProbability(std::span<const double> values, std::sp
             if (count == 0)
                 return;
 
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double cached_lambda, cached_log_lambda, cached_exp_neg_lambda;
-            [[maybe_unused]] bool cached_is_small_lambda;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_)
-                        dist.updateCacheUnsafe();
-                    cached_lambda = dist.lambda_;
-                    cached_log_lambda = dist.logLambda_;
-                    cached_exp_neg_lambda = dist.expNegLambda_;
-                    cached_is_small_lambda = dist.isSmallLambda_;
-                } else {
-                    cached_lambda = dist.lambda_;
-                    cached_log_lambda = dist.logLambda_;
-                    cached_exp_neg_lambda = dist.expNegLambda_;
-                    cached_is_small_lambda = dist.isSmallLambda_;
-                }
-            }
-
-            // Use work-stealing pool for dynamic load balancing
+            dist.withCacheSnapshot([&] {
+                cached_lambda = dist.lambda_;
+                cached_log_lambda = dist.logLambda_;
+                cached_exp_neg_lambda = dist.expNegLambda_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 if (vals[i] < detail::ZERO_DOUBLE) {
                     res[i] = detail::ZERO_DOUBLE;

--- a/src/rayleigh.cpp
+++ b/src/rayleigh.cpp
@@ -197,59 +197,33 @@ double RayleighDistribution::getProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lnc = logNormConst_;
-        const double neg_half_inv_sigma2 = negHalfInvSigmaSquared_;
-        return std::exp(std::log(x) + lnc + neg_half_inv_sigma2 * x * x);
-    }
-    // Compute inline using cached values rather than re-acquiring cache_mutex_
-    // via getLogProbability(): re-entrant shared_lock deadlocks on Linux/Windows.
-    const double lnc = logNormConst_;
-    const double neg_half_inv_sigma2 = negHalfInvSigmaSquared_;
-    lock.unlock();
-    return std::exp(std::log(x) + lnc + neg_half_inv_sigma2 * x * x);
+    double lnc, nhis;
+    withCacheSnapshot([&] {
+        lnc = logNormConst_;
+        nhis = negHalfInvSigmaSquared_;
+    });
+    return std::exp(std::log(x) + lnc + nhis * x * x);
 }
 
 double RayleighDistribution::getLogProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::NEGATIVE_INFINITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lnc = logNormConst_;
-        const double nhis = negHalfInvSigmaSquared_;
-        return std::log(x) + lnc + nhis * x * x;
-    }
-    // log(x) + logNormConst_ + negHalfInvSigmaSquared_ * x²
-    return std::log(x) + logNormConst_ + negHalfInvSigmaSquared_ * x * x;
+    double lnc, nhis;
+    withCacheSnapshot([&] {
+        lnc = logNormConst_;
+        nhis = negHalfInvSigmaSquared_;
+    });
+    return std::log(x) + lnc + nhis * x * x;
 }
 
 double RayleighDistribution::getCumulativeProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double nhis = negHalfInvSigmaSquared_;
-        return detail::ONE - std::exp(nhis * x * x);
-    }
-    return detail::ONE - std::exp(negHalfInvSigmaSquared_ * x * x);
+    double nhis;
+    withCacheSnapshot([&] { nhis = negHalfInvSigmaSquared_; });
+    return detail::ONE - std::exp(nhis * x * x);
 }
 
 double RayleighDistribution::getQuantile(double p) const {
@@ -261,35 +235,14 @@ double RayleighDistribution::getQuantile(double p) const {
     if (p == detail::ONE)
         return std::numeric_limits<double>::infinity();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double s = sigma_;
-        return s * std::sqrt(-detail::TWO * std::log(detail::ONE - p));
-    }
-    // σ·√(−2·log(1−p))
-    return sigma_ * std::sqrt(-detail::TWO * std::log(detail::ONE - p));
+    double s;
+    withCacheSnapshot([&] { s = sigma_; });
+    return s * std::sqrt(-detail::TWO * std::log(detail::ONE - p));
 }
 
 double RayleighDistribution::sample(std::mt19937& rng) const {
     double s;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            s = sigma_;
-        } else {
-            s = sigma_;
-        }
-    }
-    // Inverse-CDF: x = σ·√(−2·log(U)), U ~ Uniform(0,1)
+    withCacheSnapshot([&] { s = sigma_; });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
     return s * std::sqrt(-detail::TWO * std::log(uniform(rng)));
 }
@@ -299,19 +252,7 @@ std::vector<double> RayleighDistribution::sample(std::mt19937& rng, size_t n) co
     samples.reserve(n);
 
     double s;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            s = sigma_;
-        } else {
-            s = sigma_;
-        }
-    }
-
+    withCacheSnapshot([&] { s = sigma_; });
     std::uniform_real_distribution<double> uniform(std::numeric_limits<double>::min(), detail::ONE);
     for (size_t i = 0; i < n; ++i) {
         samples.push_back(s * std::sqrt(-detail::TWO * std::log(uniform(rng))));
@@ -391,20 +332,9 @@ double RayleighDistribution::getMedian() const {
 }
 
 double RayleighDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double ls = logSigma_;
-        return detail::ONE + ls - detail::HALF * detail::LN2 +
-               detail::HALF * detail::EULER_MASCHERONI;
-    }
-    // H = 1 + log(σ/√2) + γ/2 = 1 + log(σ) − ½·log(2) + γ/2
-    return detail::ONE + logSigma_ - detail::HALF * detail::LN2 +
-           detail::HALF * detail::EULER_MASCHERONI;
+    double ls;
+    withCacheSnapshot([&] { ls = logSigma_; });
+    return detail::ONE + ls - detail::HALF * detail::LN2 + detail::HALF * detail::EULER_MASCHERONI;
 }
 
 //==============================================================================
@@ -417,19 +347,11 @@ void RayleighDistribution::getProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::PDF,
         [](const RayleighDistribution& d, double x) { return d.getProbability(x); },
         [](const RayleighDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double nhis = d.negHalfInvSigmaSquared_, lnc = d.logNormConst_;
-                d.getProbabilityBatchUnsafeImpl(vals, res, count, nhis, lnc);
-                return;
-            }
-            const double nhis = d.negHalfInvSigmaSquared_, lnc = d.logNormConst_;
-            lock.unlock();
+            double nhis, lnc;
+            d.withCacheSnapshot([&] {
+                nhis = d.negHalfInvSigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             d.getProbabilityBatchUnsafeImpl(vals, res, count, nhis, lnc);
         },
         [](const RayleighDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -439,20 +361,10 @@ void RayleighDistribution::getProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
             double nhis, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                } else {
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                nhis = d.negHalfInvSigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -473,20 +385,10 @@ void RayleighDistribution::getProbability(std::span<const double> values, std::s
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
             double nhis, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                } else {
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                nhis = d.negHalfInvSigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] = (x <= detail::ZERO_DOUBLE) ? detail::ZERO_DOUBLE
@@ -503,19 +405,11 @@ void RayleighDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const RayleighDistribution& d, double x) { return d.getLogProbability(x); },
         [](const RayleighDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double nhis = d.negHalfInvSigmaSquared_, lnc = d.logNormConst_;
-                d.getLogProbabilityBatchUnsafeImpl(vals, res, count, nhis, lnc);
-                return;
-            }
-            const double nhis = d.negHalfInvSigmaSquared_, lnc = d.logNormConst_;
-            lock.unlock();
+            double nhis, lnc;
+            d.withCacheSnapshot([&] {
+                nhis = d.negHalfInvSigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             d.getLogProbabilityBatchUnsafeImpl(vals, res, count, nhis, lnc);
         },
         [](const RayleighDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -525,20 +419,10 @@ void RayleighDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
             double nhis, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                } else {
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                nhis = d.negHalfInvSigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -557,20 +441,10 @@ void RayleighDistribution::getLogProbability(std::span<const double> values,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
             double nhis, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                } else {
-                    nhis = d.negHalfInvSigmaSquared_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                nhis = d.negHalfInvSigmaSquared_;
+                lnc = d.logNormConst_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] = (x <= detail::ZERO_DOUBLE) ? detail::NEGATIVE_INFINITY
@@ -587,19 +461,8 @@ void RayleighDistribution::getCumulativeProbability(std::span<const double> valu
         *this, values, results, hint, detail::OperationType::CDF,
         [](const RayleighDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const RayleighDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double nhis = d.negHalfInvSigmaSquared_;
-                d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, nhis);
-                return;
-            }
-            const double nhis = d.negHalfInvSigmaSquared_;
-            lock.unlock();
+            double nhis;
+            d.withCacheSnapshot([&] { nhis = d.negHalfInvSigmaSquared_; });
             d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, nhis);
         },
         [](const RayleighDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -609,18 +472,7 @@ void RayleighDistribution::getCumulativeProbability(std::span<const double> valu
             if (count == 0)
                 return;
             double nhis;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    nhis = d.negHalfInvSigmaSquared_;
-                } else {
-                    nhis = d.negHalfInvSigmaSquared_;
-                }
-            }
+            d.withCacheSnapshot([&] { nhis = d.negHalfInvSigmaSquared_; });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -639,18 +491,7 @@ void RayleighDistribution::getCumulativeProbability(std::span<const double> valu
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
             double nhis;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    nhis = d.negHalfInvSigmaSquared_;
-                } else {
-                    nhis = d.negHalfInvSigmaSquared_;
-                }
-            }
+            d.withCacheSnapshot([&] { nhis = d.negHalfInvSigmaSquared_; });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] = (x <= detail::ZERO_DOUBLE) ? detail::ZERO_DOUBLE

--- a/src/student_t.cpp
+++ b/src/student_t.cpp
@@ -198,34 +198,23 @@ double StudentTDistribution::getKurtosis() const {
 //==============================================================================
 
 double StudentTDistribution::getProbability(double x) const {
-    // Snapshot cached fields under the appropriate lock; no re-acquire = no TOCTOU gap.
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lnc = logNormConst_, nhnpo = negHalfNuPlusOne_, inv_nu = invNu_;
-        return std::exp(lnc + nhnpo * std::log1p(x * x * inv_nu));
-    }
-    // std::log1p(x²/ν) avoids catastrophic cancellation near x≈0 vs log(1+x²/ν)
-    return std::exp(logNormConst_ + negHalfNuPlusOne_ * std::log1p(x * x * invNu_));
+    double lnc, nhnpo, inv_nu;
+    withCacheSnapshot([&] {
+        lnc = logNormConst_;
+        nhnpo = negHalfNuPlusOne_;
+        inv_nu = invNu_;
+    });
+    return std::exp(lnc + nhnpo * std::log1p(x * x * inv_nu));
 }
 
 double StudentTDistribution::getLogProbability(double x) const {
-    // Snapshot cached fields under the appropriate lock; no re-acquire = no TOCTOU gap.
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lnc = logNormConst_, nhnpo = negHalfNuPlusOne_, inv_nu = invNu_;
-        return lnc + nhnpo * std::log1p(x * x * inv_nu);
-    }
-    return logNormConst_ + negHalfNuPlusOne_ * std::log1p(x * x * invNu_);
+    double lnc, nhnpo, inv_nu;
+    withCacheSnapshot([&] {
+        lnc = logNormConst_;
+        nhnpo = negHalfNuPlusOne_;
+        inv_nu = invNu_;
+    });
+    return lnc + nhnpo * std::log1p(x * x * inv_nu);
 }
 
 double StudentTDistribution::getCumulativeProbability(double x) const {
@@ -430,25 +419,12 @@ void StudentTDistribution::getProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::PDF,
         [](const StudentTDistribution& dist, double value) { return dist.getProbability(value); },
         [](const StudentTDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    dist.updateCacheUnsafe();
-                }
-                // Snapshot while unique_lock is still held.
-                const double lnc = dist.logNormConst_;
-                const double nhnpo = dist.negHalfNuPlusOne_;
-                const double inv_nu = dist.invNu_;
-                dist.getProbabilityBatchUnsafeImpl(vals, res, count, lnc, nhnpo, inv_nu);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double lnc = dist.logNormConst_;
-            const double nhnpo = dist.negHalfNuPlusOne_;
-            const double inv_nu = dist.invNu_;
-            lock.unlock();
+            double lnc, nhnpo, inv_nu;
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                nhnpo = dist.negHalfNuPlusOne_;
+                inv_nu = dist.invNu_;
+            });
             dist.getProbabilityBatchUnsafeImpl(vals, res, count, lnc, nhnpo, inv_nu);
         },
         [](const StudentTDistribution& dist, std::span<const double> vals, std::span<double> res) {
@@ -459,23 +435,11 @@ void StudentTDistribution::getProbability(std::span<const double> values, std::s
             if (count == 0)
                 return;
             double lnc, nhnpo, inv_nu;
-            {
-                std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                    if (!dist.cache_valid_) {
-                        dist.updateCacheUnsafe();
-                    }
-                    lnc = dist.logNormConst_;
-                    nhnpo = dist.negHalfNuPlusOne_;
-                    inv_nu = dist.invNu_;
-                } else {
-                    lnc = dist.logNormConst_;
-                    nhnpo = dist.negHalfNuPlusOne_;
-                    inv_nu = dist.invNu_;
-                }
-            }
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                nhnpo = dist.negHalfNuPlusOne_;
+                inv_nu = dist.invNu_;
+            });
             // std::log1p(x²/ν) avoids catastrophic cancellation when x²/ν ≈ 0;
             // log(1 + x²/ν) loses precision there. See <cmath>: log1p(x) = log(1+x).
             if (arch::should_use_parallel(count)) {
@@ -517,25 +481,12 @@ void StudentTDistribution::getLogProbability(std::span<const double> values,
             return dist.getLogProbability(value);
         },
         [](const StudentTDistribution& dist, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
-            if (!dist.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
-                if (!dist.cache_valid_) {
-                    dist.updateCacheUnsafe();
-                }
-                // Snapshot while unique_lock is still held.
-                const double lnc = dist.logNormConst_;
-                const double nhnpo = dist.negHalfNuPlusOne_;
-                const double inv_nu = dist.invNu_;
-                dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, lnc, nhnpo, inv_nu);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double lnc = dist.logNormConst_;
-            const double nhnpo = dist.negHalfNuPlusOne_;
-            const double inv_nu = dist.invNu_;
-            lock.unlock();
+            double lnc, nhnpo, inv_nu;
+            dist.withCacheSnapshot([&] {
+                lnc = dist.logNormConst_;
+                nhnpo = dist.negHalfNuPlusOne_;
+                inv_nu = dist.invNu_;
+            });
             dist.getLogProbabilityBatchUnsafeImpl(vals, res, count, lnc, nhnpo, inv_nu);
         },
         [](const StudentTDistribution& dist, std::span<const double> vals, std::span<double> res) {

--- a/src/uniform.cpp
+++ b/src/uniform.cpp
@@ -270,118 +270,59 @@ VoidResult UniformDistribution::trySetParameters(double a, double b) noexcept {
 
 double UniformDistribution::getProbability(double x) const {
     // Ensure cache is valid once before using - using the same pattern as other methods
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lo = a_, hi = b_;
-        const bool is_unit = isUnitInterval_;
-        const double inv_w = invWidth_;
-        if (std::isnan(x))
-            return std::numeric_limits<double>::quiet_NaN();
-        if (x < lo || x > hi)
-            return detail::ZERO_DOUBLE;
-        if (is_unit)
-            return detail::ONE;
-        return inv_w;
-    }
-
-    // NaN must propagate before the bounds checks (both comparisons are false for NaN,
-    // so NaN would silently pass through and return the density constant).
     if (std::isnan(x))
         return std::numeric_limits<double>::quiet_NaN();
-
-    // Check if x is within the support [a, b]
-    if (x < a_ || x > b_) {
+    double lo, hi, inv_w;
+    bool is_unit;
+    withCacheSnapshot([&] {
+        lo = a_;
+        hi = b_;
+        is_unit = isUnitInterval_;
+        inv_w = invWidth_;
+    });
+    if (x < lo || x > hi)
         return detail::ZERO_DOUBLE;
-    }
-
-    // Fast path for unit interval [0,1]
-    if (isUnitInterval_) {
+    if (is_unit)
         return detail::ONE;
-    }
-
-    // General case: PDF = 1/(b-a) for x in [a,b]
-    return invWidth_;
+    return inv_w;
 }
 
 double UniformDistribution::getLogProbability(double x) const {
     // Ensure cache is valid
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lo = a_, hi = b_;
-        const bool is_unit = isUnitInterval_;
-        const double w = width_;
-        if (std::isnan(x))
-            return std::numeric_limits<double>::quiet_NaN();
-        if (x < lo || x > hi)
-            return detail::NEGATIVE_INFINITY;
-        if (is_unit)
-            return detail::ZERO_DOUBLE;
-        return -std::log(w);
-    }
-
     if (std::isnan(x))
         return std::numeric_limits<double>::quiet_NaN();
-
-    // Check if x is within the support [a, b]
-    if (x < a_ || x > b_) {
+    double lo, hi, w;
+    bool is_unit;
+    withCacheSnapshot([&] {
+        lo = a_;
+        hi = b_;
+        is_unit = isUnitInterval_;
+        w = width_;
+    });
+    if (x < lo || x > hi)
         return detail::NEGATIVE_INFINITY;
-    }
-
-    // Fast path for unit interval [0,1]
-    if (isUnitInterval_) {
-        return detail::ZERO_DOUBLE;  // log(1) = 0
-    }
-
-    // General case: log(PDF) = log(1/(b-a)) = -log(b-a)
-    return -std::log(width_);
+    if (is_unit)
+        return detail::ZERO_DOUBLE;
+    return -std::log(w);
 }
 
 double UniformDistribution::getCumulativeProbability(double x) const {
     // Ensure cache is valid
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double lo = a_, hi = b_;
-        const bool is_unit = isUnitInterval_;
-        const double inv_w = invWidth_;
-        if (x < lo)
-            return detail::ZERO_DOUBLE;
-        if (x > hi)
-            return detail::ONE;
-        if (is_unit)
-            return x;
-        return (x - lo) * inv_w;
-    }
-
-    // CDF for uniform distribution
-    if (x < a_) {
+    double lo, hi, inv_w;
+    bool is_unit;
+    withCacheSnapshot([&] {
+        lo = a_;
+        hi = b_;
+        is_unit = isUnitInterval_;
+        inv_w = invWidth_;
+    });
+    if (x < lo)
         return detail::ZERO_DOUBLE;
-    }
-    if (x > b_) {
+    if (x > hi)
         return detail::ONE;
-    }
-
-    // Fast path for unit interval [0,1]
-    if (isUnitInterval_) {
-        return x;  // CDF(x) = x for U(0,1)
-    }
-
-    // General case: CDF(x) = (x-a)/(b-a)
-    return (x - a_) * invWidth_;
+    if (is_unit)
+        return x;
+    return (x - lo) * inv_w;
 }
 
 double UniformDistribution::getQuantile(double p) const {
@@ -396,49 +337,26 @@ double UniformDistribution::getQuantile(double p) const {
         return b_;
     }
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const bool is_unit = isUnitInterval_;
-        const double lo = a_, w = width_;
-        if (is_unit)
-            return p;
-        return lo + p * w;
-    }
-
-    // Fast path for unit interval [0,1]
-    if (isUnitInterval_) {
-        return p;  // Quantile(p) = p for U(0,1)
-    }
-
-    // General case: Quantile(p) = a + p*(b-a)
-    return a_ + p * width_;
+    double lo, w;
+    bool is_unit;
+    withCacheSnapshot([&] {
+        lo = a_;
+        is_unit = isUnitInterval_;
+        w = width_;
+    });
+    if (is_unit)
+        return p;
+    return lo + p * w;
 }
 
 double UniformDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     bool cached_is_unit_interval;
     double cached_a, cached_width;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            cached_is_unit_interval = isUnitInterval_;
-            cached_a = a_;
-            cached_width = width_;
-        } else {
-            cached_is_unit_interval = isUnitInterval_;
-            cached_a = a_;
-            cached_width = width_;
-        }
-    }
+    withCacheSnapshot([&] {
+        cached_is_unit_interval = isUnitInterval_;
+        cached_a = a_;
+        cached_width = width_;
+    });
 
     // Use high-quality uniform distribution
     std::uniform_real_distribution<double> uniform(detail::ZERO_DOUBLE, detail::ONE);

--- a/src/von_mises.cpp
+++ b/src/von_mises.cpp
@@ -223,17 +223,9 @@ double VonMisesDistribution::getMean() const {
 }
 
 double VonMisesDistribution::getVariance() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double cv = circularVariance_;
-        return cv;
-    }
-    return circularVariance_;
+    double cv;
+    withCacheSnapshot([&] { cv = circularVariance_; });
+    return cv;
 }
 
 //==============================================================================
@@ -295,17 +287,13 @@ double VonMisesDistribution::getProbability(double x) const {
     if (!std::isfinite(x))
         return detail::ZERO_DOUBLE;  // ±inf → PDF is 0
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double k = kappa_, mu = mu_, lnorm = logNormaliser_;
-        return std::exp(k * std::cos(x - mu) - lnorm);
-    }
-    return std::exp(kappa_ * std::cos(x - mu_) - logNormaliser_);
+    double k, mu, lnorm;
+    withCacheSnapshot([&] {
+        k = kappa_;
+        mu = mu_;
+        lnorm = logNormaliser_;
+    });
+    return std::exp(k * std::cos(x - mu) - lnorm);
 }
 
 double VonMisesDistribution::getLogProbability(double x) const {
@@ -314,17 +302,13 @@ double VonMisesDistribution::getLogProbability(double x) const {
     if (!std::isfinite(x))
         return detail::NEGATIVE_INFINITY;  // ±inf → log PDF is -∞
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const double k = kappa_, mu = mu_, lnorm = logNormaliser_;
-        return k * std::cos(x - mu) - lnorm;
-    }
-    return kappa_ * std::cos(x - mu_) - logNormaliser_;
+    double k, mu, lnorm;
+    withCacheSnapshot([&] {
+        k = kappa_;
+        mu = mu_;
+        lnorm = logNormaliser_;
+    });
+    return k * std::cos(x - mu) - lnorm;
 }
 
 double VonMisesDistribution::getCumulativeProbability(double x) const {
@@ -336,24 +320,12 @@ double VonMisesDistribution::getCumulativeProbability(double x) const {
 
     const double v = wrapAngle(x);
 
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double kappa, mu, lnorm;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            kappa = kappa_;
-            mu = mu_;
-            lnorm = logNormaliser_;
-        } else {
-            kappa = kappa_;
-            mu = mu_;
-            lnorm = logNormaliser_;
-        }
-    }
+    withCacheSnapshot([&] {
+        kappa = kappa_;
+        mu = mu_;
+        lnorm = logNormaliser_;
+    });
 
     // For large κ, VM(μ, κ) ≈ N(μ, 1/κ) on the circle — use the wrapped normal CDF.
     // Approximation error is O(1/κ²); < 1e-4 for κ > 50.
@@ -461,22 +433,11 @@ double VonMisesDistribution::getQuantile(double p) const {
 }
 
 double VonMisesDistribution::sample(std::mt19937& rng) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double kappa, mu;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            kappa = kappa_;
-            mu = mu_;
-        } else {
-            kappa = kappa_;
-            mu = mu_;
-        }
-    }
+    withCacheSnapshot([&] {
+        kappa = kappa_;
+        mu = mu_;
+    });
 
     // Near-uniform case (κ ≈ 0): sample uniformly on the circle.
     if (kappa < 1e-9) {
@@ -516,22 +477,11 @@ double VonMisesDistribution::sample(std::mt19937& rng) const {
 }
 
 std::vector<double> VonMisesDistribution::sample(std::mt19937& rng, size_t n) const {
-    // Snapshot parameters under the appropriate lock to avoid TOCTOU.
     double kappa, mu;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            kappa = kappa_;
-            mu = mu_;
-        } else {
-            kappa = kappa_;
-            mu = mu_;
-        }
-    }
+    withCacheSnapshot([&] {
+        kappa = kappa_;
+        mu = mu_;
+    });
 
     std::vector<double> samples;
     samples.reserve(n);
@@ -644,32 +594,21 @@ double VonMisesDistribution::getMode() const {
 }
 
 double VonMisesDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-        const bool is_uniform = isUniform_;
-        const double k = kappa_;
-        if (is_uniform)
-            return detail::LN_2PI;
-        const double log_i0 = detail::log_bessel_i0(k);
-        const double i0 = detail::bessel_i0(k);
-        const double i1 = detail::bessel_i1(k);
-        const double A1 = (i0 > 0.0) ? i1 / i0 : 0.0;
-        return detail::LN_2PI - log_i0 + k * A1;
-    }
+    bool is_uniform;
+    double k;
+    withCacheSnapshot([&] {
+        is_uniform = isUniform_;
+        k = kappa_;
+    });
     // H = log(2π) − log I₀(κ) + κ·I₁(κ)/I₀(κ)
     // At κ=0: H = log(2π) − log(1) + 0 = log(2π) ✓ (uniform on the circle)
-    if (isUniform_)
+    if (is_uniform)
         return detail::LN_2PI;
-    const double log_i0 = detail::log_bessel_i0(kappa_);
-    const double i0 = detail::bessel_i0(kappa_);
-    const double i1 = detail::bessel_i1(kappa_);
+    const double log_i0 = detail::log_bessel_i0(k);
+    const double i0 = detail::bessel_i0(k);
+    const double i1 = detail::bessel_i1(k);
     const double A1 = (i0 > 0.0) ? i1 / i0 : 0.0;
-    return detail::LN_2PI - log_i0 + kappa_ * A1;
+    return detail::LN_2PI - log_i0 + k * A1;
 }
 
 //==============================================================================
@@ -682,20 +621,12 @@ void VonMisesDistribution::getProbability(std::span<const double> values, std::s
         *this, values, results, hint, detail::OperationType::PDF,
         [](const VonMisesDistribution& d, double x) { return d.getProbability(x); },
         [](const VonMisesDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
-                d.getProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
-            lock.unlock();
+            double k, mu, lnorm;
+            d.withCacheSnapshot([&] {
+                k = d.kappa_;
+                mu = d.mu_;
+                lnorm = d.logNormaliser_;
+            });
             d.getProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -704,24 +635,12 @@ void VonMisesDistribution::getProbability(std::span<const double> values, std::s
             const std::size_t count = vals.size();
             if (count == 0)
                 return;
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double k, mu, lnorm;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                } else {
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.kappa_;
+                mu = d.mu_;
+                lnorm = d.logNormaliser_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -739,24 +658,12 @@ void VonMisesDistribution::getProbability(std::span<const double> values, std::s
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double k, mu, lnorm;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                } else {
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.kappa_;
+                mu = d.mu_;
+                lnorm = d.logNormaliser_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] =
@@ -773,20 +680,12 @@ void VonMisesDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const VonMisesDistribution& d, double x) { return d.getLogProbability(x); },
         [](const VonMisesDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held — eliminates TOCTOU gap.
-                const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
-                d.getLogProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
-                return;
-            }
-            // Cache hit — snapshot under shared_lock.
-            const double k = d.kappa_, mu = d.mu_, lnorm = d.logNormaliser_;
-            lock.unlock();
+            double k, mu, lnorm;
+            d.withCacheSnapshot([&] {
+                k = d.kappa_;
+                mu = d.mu_;
+                lnorm = d.logNormaliser_;
+            });
             d.getLogProbabilityBatchUnsafeImpl(vals, res, count, k, mu, lnorm);
         },
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -795,24 +694,12 @@ void VonMisesDistribution::getLogProbability(std::span<const double> values,
             const std::size_t count = vals.size();
             if (count == 0)
                 return;
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double k, mu, lnorm;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                } else {
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.kappa_;
+                mu = d.mu_;
+                lnorm = d.logNormaliser_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -830,24 +717,12 @@ void VonMisesDistribution::getLogProbability(std::span<const double> values,
         [](const VonMisesDistribution& d, std::span<const double> vals, std::span<double> res,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
-            // Snapshot parameters under the appropriate lock to avoid TOCTOU.
             double k, mu, lnorm;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                } else {
-                    k = d.kappa_;
-                    mu = d.mu_;
-                    lnorm = d.logNormaliser_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.kappa_;
+                mu = d.mu_;
+                lnorm = d.logNormaliser_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] =

--- a/src/weibull.cpp
+++ b/src/weibull.cpp
@@ -166,92 +166,52 @@ void WeibullDistribution::setParameters(double shape, double scale) {
 }
 
 double WeibullDistribution::getMean() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return mean_;  // snapshot + early return under unique_lock
-    }
-    return mean_;
+    double m;
+    withCacheSnapshot([&] { m = mean_; });
+    return m;
 }
 
 double WeibullDistribution::getVariance() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        return variance_;  // snapshot + early return under unique_lock
-    }
-    return variance_;
+    double v;
+    withCacheSnapshot([&] { v = variance_; });
+    return v;
 }
 
 double WeibullDistribution::getSkewness() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_, sc = scale_, var = variance_;
-        const double g1 = std::exp(detail::lgamma(detail::ONE + detail::ONE / k));
-        const double g2 = std::exp(detail::lgamma(detail::ONE + detail::TWO / k));
-        const double g3 = std::exp(detail::lgamma(detail::ONE + detail::THREE / k));
-        const double var_raw = g2 - g1 * g1;
-        if (var_raw <= detail::ZERO)
-            return detail::ZERO_DOUBLE;
-        const double num = g3 - detail::THREE * g1 * g2 + detail::TWO * g1 * g1 * g1;
-        return sc * sc * sc * num / (var * std::sqrt(var));
-    }
-    // Cache hit: read under shared_lock.
-    // Skewness = [Γ(1+3/k)λ³ − 3μσ² − μ³] / σ³  where σ² = variance_
-    // More efficiently via standardized moments:
-    const double g1 = std::exp(detail::lgamma(detail::ONE + detail::ONE / shape_));
-    const double g2 = std::exp(detail::lgamma(detail::ONE + detail::TWO / shape_));
-    const double g3 = std::exp(detail::lgamma(detail::ONE + detail::THREE / shape_));
-    const double var_raw = g2 - g1 * g1;  // λ-normalised variance
+    double k, sc, var;
+    withCacheSnapshot([&] {
+        k = shape_;
+        sc = scale_;
+        var = variance_;
+    });
+    const double g1 = std::exp(detail::lgamma(detail::ONE + detail::ONE / k));
+    const double g2 = std::exp(detail::lgamma(detail::ONE + detail::TWO / k));
+    const double g3 = std::exp(detail::lgamma(detail::ONE + detail::THREE / k));
+    const double var_raw = g2 - g1 * g1;
     if (var_raw <= detail::ZERO)
         return detail::ZERO_DOUBLE;
     const double num = g3 - detail::THREE * g1 * g2 + detail::TWO * g1 * g1 * g1;
-    return scale_ * scale_ * scale_ * num / (variance_ * std::sqrt(variance_));
+    return sc * sc * sc * num / (var * std::sqrt(var));
 }
 
 double WeibullDistribution::getKurtosis() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_, sc = scale_, var = variance_;
-        const double g1 = std::exp(detail::lgamma(detail::ONE + detail::ONE / k));
-        const double g2 = std::exp(detail::lgamma(detail::ONE + detail::TWO / k));
-        const double g3 = std::exp(detail::lgamma(detail::ONE + detail::THREE / k));
-        const double g4 = std::exp(detail::lgamma(detail::ONE + detail::FOUR / k));
-        const double var_raw = g2 - g1 * g1;
-        if (var_raw <= detail::ZERO)
-            return detail::ZERO_DOUBLE;
-        const double m4 = (g4 - detail::FOUR * g3 * g1 + detail::SIX * g2 * g1 * g1 -
-                           detail::THREE * g1 * g1 * g1 * g1);
-        return sc * sc * sc * sc * m4 / (var * var) - detail::THREE;
-    }
-    // Cache hit: read under shared_lock.
-    const double g1 = std::exp(detail::lgamma(detail::ONE + detail::ONE / shape_));
-    const double g2 = std::exp(detail::lgamma(detail::ONE + detail::TWO / shape_));
-    const double g3 = std::exp(detail::lgamma(detail::ONE + detail::THREE / shape_));
-    const double g4 = std::exp(detail::lgamma(detail::ONE + detail::FOUR / shape_));
+    double k, sc, var;
+    withCacheSnapshot([&] {
+        k = shape_;
+        sc = scale_;
+        var = variance_;
+    });
+    const double g1 = std::exp(detail::lgamma(detail::ONE + detail::ONE / k));
+    const double g2 = std::exp(detail::lgamma(detail::ONE + detail::TWO / k));
+    const double g3 = std::exp(detail::lgamma(detail::ONE + detail::THREE / k));
+    const double g4 = std::exp(detail::lgamma(detail::ONE + detail::FOUR / k));
     const double var_raw = g2 - g1 * g1;
     if (var_raw <= detail::ZERO)
         return detail::ZERO_DOUBLE;
     // Raw fourth central moment (λ-normalised) / normalised-variance² − 3
     const double m4 = (g4 - detail::FOUR * g3 * g1 + detail::SIX * g2 * g1 * g1 -
                        detail::THREE * g1 * g1 * g1 * g1);
-    return scale_ * scale_ * scale_ * scale_ * m4 / (variance_ * variance_) - detail::THREE;
+    return sc * sc * sc * sc * m4 / (var * var) - detail::THREE;
 }
 
 //==============================================================================
@@ -311,43 +271,19 @@ double WeibullDistribution::getProbability(double x) const {
     if (x < detail::ZERO_DOUBLE)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_;
-        const double ls = logScale_;
-        const double km1 = shapeMinus1_;
-        const double lnc = logNormConst_;
-        const double sc = scale_;
-        if (x == detail::ZERO_DOUBLE) {
-            if (std::abs(k - detail::ONE) <= detail::DEFAULT_TOLERANCE)
-                return detail::ONE / sc;
-            return (k > detail::ONE) ? detail::ZERO_DOUBLE
-                                     : std::numeric_limits<double>::infinity();
-        }
-        const double log_x = std::log(x);
-        const double z = log_x - ls;
-        return std::exp(lnc + km1 * log_x - std::exp(k * z));
-    }
-    // At x = 0: PDF = 1/λ for k=1; 0 for k>1; +∞ for k<1
-    // getLogProbability correctly returns +inf / -inf; getProbability must match.
+    double k, ls, km1, lnc, sc;
+    withCacheSnapshot([&] {
+        k = shape_;
+        ls = logScale_;
+        km1 = shapeMinus1_;
+        lnc = logNormConst_;
+        sc = scale_;
+    });
     if (x == detail::ZERO_DOUBLE) {
-        if (std::abs(shape_ - detail::ONE) <= detail::DEFAULT_TOLERANCE)
-            return detail::ONE / scale_;
-        return (shape_ > detail::ONE) ? detail::ZERO_DOUBLE
-                                      : std::numeric_limits<double>::infinity();
+        if (std::abs(k - detail::ONE) <= detail::DEFAULT_TOLERANCE)
+            return detail::ONE / sc;
+        return (k > detail::ONE) ? detail::ZERO_DOUBLE : std::numeric_limits<double>::infinity();
     }
-    // Compute inline using cached values rather than re-acquiring cache_mutex_
-    // via getLogProbability(): re-entrant shared_lock deadlocks on Linux/Windows.
-    const double k = shape_;
-    const double ls = logScale_;
-    const double km1 = shapeMinus1_;
-    const double lnc = logNormConst_;
-    lock.unlock();
     const double log_x = std::log(x);
     const double z = log_x - ls;
     return std::exp(lnc + km1 * log_x - std::exp(k * z));
@@ -357,56 +293,35 @@ double WeibullDistribution::getLogProbability(double x) const {
     if (x < detail::ZERO_DOUBLE)
         return detail::NEGATIVE_INFINITY;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_;
-        const double ls = logScale_;
-        const double km1 = shapeMinus1_;
-        const double lnc = logNormConst_;
-        if (x == detail::ZERO_DOUBLE) {
-            if (std::abs(k - detail::ONE) <= detail::DEFAULT_TOLERANCE)
-                return -ls;
-            return (k > detail::ONE) ? detail::NEGATIVE_INFINITY
-                                     : std::numeric_limits<double>::infinity();
-        }
-        const double log_x = std::log(x);
-        const double z = log_x - ls;
-        const double power = std::exp(k * z);
-        return lnc + km1 * log_x - power;
-    }
+    double k, ls, km1, lnc;
+    withCacheSnapshot([&] {
+        k = shape_;
+        ls = logScale_;
+        km1 = shapeMinus1_;
+        lnc = logNormConst_;
+    });
     if (x == detail::ZERO_DOUBLE) {
-        // k=1: log(1/λ); k>1: −∞; k<1: +∞
-        if (std::abs(shape_ - detail::ONE) <= detail::DEFAULT_TOLERANCE)
-            return -logScale_;
-        return (shape_ > detail::ONE) ? detail::NEGATIVE_INFINITY
-                                      : std::numeric_limits<double>::infinity();
+        if (std::abs(k - detail::ONE) <= detail::DEFAULT_TOLERANCE)
+            return -ls;
+        return (k > detail::ONE) ? detail::NEGATIVE_INFINITY
+                                 : std::numeric_limits<double>::infinity();
     }
     const double log_x = std::log(x);
-    const double z = log_x - logScale_;         // log(x/λ)
-    const double power = std::exp(shape_ * z);  // (x/λ)^k
-    return logNormConst_ + shapeMinus1_ * log_x - power;
+    const double z = log_x - ls;
+    const double power = std::exp(k * z);
+    return lnc + km1 * log_x - power;
 }
 
 double WeibullDistribution::getCumulativeProbability(double x) const {
     if (x <= detail::ZERO_DOUBLE)
         return detail::ZERO_DOUBLE;
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_, ls = logScale_;
-        return detail::ONE - std::exp(-std::exp(k * (std::log(x) - ls)));
-    }
-    return detail::ONE - std::exp(-std::exp(shape_ * (std::log(x) - logScale_)));
+    double k, ls;
+    withCacheSnapshot([&] {
+        k = shape_;
+        ls = logScale_;
+    });
+    return detail::ONE - std::exp(-std::exp(k * (std::log(x) - ls)));
 }
 
 double WeibullDistribution::getQuantile(double p) const {
@@ -418,36 +333,21 @@ double WeibullDistribution::getQuantile(double p) const {
     if (p == detail::ONE)
         return std::numeric_limits<double>::infinity();
 
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double sc = scale_, k = shape_;
-        return sc * std::pow(-std::log(detail::ONE - p), detail::ONE / k);
-    }
+    double sc, k;
+    withCacheSnapshot([&] {
+        sc = scale_;
+        k = shape_;
+    });
     // Q(p) = λ · (−log(1−p))^(1/k)
-    return scale_ * std::pow(-std::log(detail::ONE - p), detail::ONE / shape_);
+    return sc * std::pow(-std::log(detail::ONE - p), detail::ONE / k);
 }
 
 double WeibullDistribution::sample(std::mt19937& rng) const {
     double k, lam;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            k = shape_;
-            lam = scale_;
-        } else {
-            k = shape_;
-            lam = scale_;
-        }
-    }
+    withCacheSnapshot([&] {
+        k = shape_;
+        lam = scale_;
+    });
     std::weibull_distribution<double> dist(k, lam);
     return dist(rng);
 }
@@ -457,20 +357,10 @@ std::vector<double> WeibullDistribution::sample(std::mt19937& rng, size_t n) con
     samples.reserve(n);
 
     double k, lam;
-    {
-        std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-        if (!cache_valid_) {
-            lock.unlock();
-            std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-            if (!cache_valid_)
-                updateCacheUnsafe();
-            k = shape_;
-            lam = scale_;
-        } else {
-            k = shape_;
-            lam = scale_;
-        }
-    }
+    withCacheSnapshot([&] {
+        k = shape_;
+        lam = scale_;
+    });
 
     std::weibull_distribution<double> dist(k, lam);
     for (size_t i = 0; i < n; ++i)
@@ -640,52 +530,35 @@ double WeibullDistribution::getScaleAtomic() const noexcept {
 }
 
 double WeibullDistribution::getMode() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_, sc = scale_;
-        if (k <= detail::ONE)
-            return detail::ZERO_DOUBLE;
-        return sc * std::pow((k - detail::ONE) / k, detail::ONE / k);
-    }
-    if (shape_ <= detail::ONE)
+    double k, sc;
+    withCacheSnapshot([&] {
+        k = shape_;
+        sc = scale_;
+    });
+    if (k <= detail::ONE)
         return detail::ZERO_DOUBLE;
-    return scale_ * std::pow((shape_ - detail::ONE) / shape_, detail::ONE / shape_);
+    return sc * std::pow((k - detail::ONE) / k, detail::ONE / k);
 }
 
 double WeibullDistribution::getMedian() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double sc = scale_, k = shape_;
-        return sc * std::pow(detail::LN2, detail::ONE / k);
-    }
+    double sc, k;
+    withCacheSnapshot([&] {
+        sc = scale_;
+        k = shape_;
+    });
     // λ·(ln 2)^(1/k)
-    return scale_ * std::pow(detail::LN2, detail::ONE / shape_);
+    return sc * std::pow(detail::LN2, detail::ONE / k);
 }
 
 double WeibullDistribution::getEntropy() const {
-    std::shared_lock<std::shared_mutex> lock(cache_mutex_);
-    if (!cache_valid_) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
-        if (!cache_valid_)
-            updateCacheUnsafe();
-        // Snapshot while unique_lock is still held.
-        const double k = shape_, ls = logScale_, lk = logShape_;
-        return detail::EULER_MASCHERONI * (detail::ONE - detail::ONE / k) + ls - lk + detail::ONE;
-    }
+    double k, ls, lk;
+    withCacheSnapshot([&] {
+        k = shape_;
+        ls = logScale_;
+        lk = logShape_;
+    });
     // H = γ·(1 − 1/k) + log(λ/k) + 1
-    return detail::EULER_MASCHERONI * (detail::ONE - detail::ONE / shape_) + logScale_ - logShape_ +
-           detail::ONE;
+    return detail::EULER_MASCHERONI * (detail::ONE - detail::ONE / k) + ls - lk + detail::ONE;
 }
 
 //==============================================================================
@@ -698,21 +571,13 @@ void WeibullDistribution::getProbability(std::span<const double> values, std::sp
         *this, values, results, hint, detail::OperationType::PDF,
         [](const WeibullDistribution& d, double x) { return d.getProbability(x); },
         [](const WeibullDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double k = d.shape_, ls = d.logScale_, km1 = d.shapeMinus1_,
-                             lnc = d.logNormConst_;
-                d.getProbabilityBatchUnsafeImpl(vals, res, count, k, ls, km1, lnc);
-                return;
-            }
-            const double k = d.shape_, ls = d.logScale_, km1 = d.shapeMinus1_,
-                         lnc = d.logNormConst_;
-            lock.unlock();
+            double k, ls, km1, lnc;
+            d.withCacheSnapshot([&] {
+                k = d.shape_;
+                ls = d.logScale_;
+                km1 = d.shapeMinus1_;
+                lnc = d.logNormConst_;
+            });
             d.getProbabilityBatchUnsafeImpl(vals, res, count, k, ls, km1, lnc);
         },
         [](const WeibullDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -722,24 +587,12 @@ void WeibullDistribution::getProbability(std::span<const double> values, std::sp
             if (count == 0)
                 return;
             double k, ls, km1, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                } else {
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.shape_;
+                ls = d.logScale_;
+                km1 = d.shapeMinus1_;
+                lnc = d.logNormConst_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -768,24 +621,12 @@ void WeibullDistribution::getProbability(std::span<const double> values, std::sp
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
             double k, ls, km1, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                } else {
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.shape_;
+                ls = d.logScale_;
+                km1 = d.shapeMinus1_;
+                lnc = d.logNormConst_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 if (x <= detail::ZERO_DOUBLE) {
@@ -807,21 +648,13 @@ void WeibullDistribution::getLogProbability(std::span<const double> values,
         *this, values, results, hint, detail::OperationType::LOG_PDF,
         [](const WeibullDistribution& d, double x) { return d.getLogProbability(x); },
         [](const WeibullDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double k = d.shape_, ls = d.logScale_, km1 = d.shapeMinus1_,
-                             lnc = d.logNormConst_;
-                d.getLogProbabilityBatchUnsafeImpl(vals, res, count, k, ls, km1, lnc);
-                return;
-            }
-            const double k = d.shape_, ls = d.logScale_, km1 = d.shapeMinus1_,
-                         lnc = d.logNormConst_;
-            lock.unlock();
+            double k, ls, km1, lnc;
+            d.withCacheSnapshot([&] {
+                k = d.shape_;
+                ls = d.logScale_;
+                km1 = d.shapeMinus1_;
+                lnc = d.logNormConst_;
+            });
             d.getLogProbabilityBatchUnsafeImpl(vals, res, count, k, ls, km1, lnc);
         },
         [](const WeibullDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -831,24 +664,12 @@ void WeibullDistribution::getLogProbability(std::span<const double> values,
             if (count == 0)
                 return;
             double k, ls, km1, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                } else {
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.shape_;
+                ls = d.logScale_;
+                km1 = d.shapeMinus1_;
+                lnc = d.logNormConst_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -877,24 +698,12 @@ void WeibullDistribution::getLogProbability(std::span<const double> values,
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
             double k, ls, km1, lnc;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                } else {
-                    k = d.shape_;
-                    ls = d.logScale_;
-                    km1 = d.shapeMinus1_;
-                    lnc = d.logNormConst_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                k = d.shape_;
+                ls = d.logScale_;
+                km1 = d.shapeMinus1_;
+                lnc = d.logNormConst_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 if (x <= detail::ZERO_DOUBLE) {
@@ -916,19 +725,11 @@ void WeibullDistribution::getCumulativeProbability(std::span<const double> value
         *this, values, results, hint, detail::OperationType::CDF,
         [](const WeibullDistribution& d, double x) { return d.getCumulativeProbability(x); },
         [](const WeibullDistribution& d, const double* vals, double* res, size_t count) {
-            std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-            if (!d.cache_valid_) {
-                lock.unlock();
-                std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                if (!d.cache_valid_)
-                    d.updateCacheUnsafe();
-                // Snapshot while unique_lock is still held.
-                const double ls = d.logScale_, k = d.shape_;
-                d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, ls, k);
-                return;
-            }
-            const double ls = d.logScale_, k = d.shape_;
-            lock.unlock();
+            double ls, k;
+            d.withCacheSnapshot([&] {
+                ls = d.logScale_;
+                k = d.shape_;
+            });
             d.getCumulativeProbabilityBatchUnsafeImpl(vals, res, count, ls, k);
         },
         [](const WeibullDistribution& d, std::span<const double> vals, std::span<double> res) {
@@ -938,20 +739,10 @@ void WeibullDistribution::getCumulativeProbability(std::span<const double> value
             if (count == 0)
                 return;
             double ls, k;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    ls = d.logScale_;
-                    k = d.shape_;
-                } else {
-                    ls = d.logScale_;
-                    k = d.shape_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                ls = d.logScale_;
+                k = d.shape_;
+            });
             if (arch::should_use_parallel(count)) {
                 ParallelUtils::parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                     const double x = vals[i];
@@ -972,20 +763,10 @@ void WeibullDistribution::getCumulativeProbability(std::span<const double> value
            WorkStealingPool& pool) {
             const std::size_t count = vals.size();
             double ls, k;
-            {
-                std::shared_lock<std::shared_mutex> lock(d.cache_mutex_);
-                if (!d.cache_valid_) {
-                    lock.unlock();
-                    std::unique_lock<std::shared_mutex> ulock(d.cache_mutex_);
-                    if (!d.cache_valid_)
-                        d.updateCacheUnsafe();
-                    ls = d.logScale_;
-                    k = d.shape_;
-                } else {
-                    ls = d.logScale_;
-                    k = d.shape_;
-                }
-            }
+            d.withCacheSnapshot([&] {
+                ls = d.logScale_;
+                k = d.shape_;
+            });
             pool.parallelFor(std::size_t{0}, count, [&](std::size_t i) {
                 const double x = vals[i];
                 res[i] = (x <= detail::ZERO_DOUBLE)


### PR DESCRIPTION
## Summary

Replaces all double-checked locking (DCL) snapshot blocks across every distribution source file with a single unified helper, `ThreadSafeCacheManager::withCacheSnapshot()`.

## Problem

Every distribution had two structurally identical DCL patterns for reading cached values under the appropriate lock:

**Pattern A** (scalar methods — early return under unique_lock):
```cpp
std::shared_lock<std::shared_mutex> lock(cache_mutex_);
if (!cache_valid_) {
    lock.unlock();
    std::unique_lock<std::shared_mutex> ulock(cache_mutex_);
    if (!cache_valid_) updateCacheUnsafe();
    return cached_field_;  // snapshot + early return under unique_lock
}
return cached_field_;
```

**Pattern B** (batch lambdas — identical assignment in both branches):
```cpp
{
    std::shared_lock<std::shared_mutex> lock(dist.cache_mutex_);
    if (!dist.cache_valid_) {
        lock.unlock();
        std::unique_lock<std::shared_mutex> ulock(dist.cache_mutex_);
        if (!dist.cache_valid_) dist.updateCacheUnsafe();
        cached_x = dist.x_;
    } else {
        cached_x = dist.x_;  // identical — no reason for two branches
    }
}
```

These patterns appeared ~200 times across 17 source files, making the codebase verbose and the locking protocol harder to audit.

## Solution

Added `withCacheSnapshot(SnapshotFn&&)` to `ThreadSafeCacheManager` in `include/core/distribution_cache.h`. The helper encapsulates the full DCL protocol — shared_lock fast path, release + unique_lock + `updateCacheUnsafe()` if stale — and calls the snapshot lambda under whichever lock is appropriate, with no TOCTOU gap in either path.

Both patterns collapse to:
```cpp
double x;
withCacheSnapshot([&] { x = x_; });
return x;
```

## Scope

- **17 distribution source files** converted: beta, binomial, cauchy, discrete, exponential, gamma, gaussian, laplace, lognormal, negative_binomial, pareto, poisson, rayleigh, student_t, uniform, von_mises, weibull
- **chi_squared** and **geometric**: delegation wrappers with no DCL blocks — unchanged
- **No API changes** — purely internal locking implementation

## Validation (M1 NEON)

- 69/69 tests pass (46 correctness + 22 timing + 1 benchmark)
- `toctou_validator`: 0 violations across all 19 distributions (10.6M concurrent reads)
- `simd_verification`: all correct; NEON speedups intact (PDF 6.5x, LogPDF 8.4x, CDF 3.2x)
- `parallel_correctness_verification`: 100% deterministic, 100% thread-safe
- All 7 example binaries run clean

---
Warp conversation: https://app.warp.dev/conversation/d307185b-6537-4f6a-9a8e-73705f8086eb

Co-Authored-By: Oz <oz-agent@warp.dev>
