### PR TITLE
fix(simd): x86 exp non-finite edge cases + vector_log_sse2 subnormals (#74)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,16 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/SIMDDetection.cmake")
 
 # Set options for SIMD detection behavior
 option(LIBSTATS_ENABLE_RUNTIME_CHECKS "Enable runtime CPU checks even when cross-compiling" OFF)
+# Cap the highest *compiled* x86 SIMD tier. Runtime dispatch always selects the
+# highest tier the CPU supports, so on an AVX2 box the AVX and SSE2 kernels never
+# execute. Setting this to SSE2 or AVX disables the tiers above it (source + define
+# removed) so the capped tier becomes the dispatch ceiling — useful for validating
+# lower-tier kernels natively. Accepts SSE2|AVX|AVX2|AVX512 (empty = no cap).
+# Honoured by detect_simd_features() -> apply_simd_tier_cap() in SIMDDetection.cmake.
+set(LIBSTATS_MAX_SIMD_TIER
+    ""
+    CACHE STRING "Cap the highest compiled x86 SIMD tier (SSE2|AVX|AVX2|AVX512; empty = no cap)")
+set_property(CACHE LIBSTATS_MAX_SIMD_TIER PROPERTY STRINGS "" SSE2 AVX AVX2 AVX512)
 # Perform comprehensive SIMD detection
 detect_simd_features()
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -50,6 +50,13 @@ Last reconciled against live GitHub state: 2026-07-19.
   — see "Issue #67" section below. Posted a comment on **#49** recording that
   the erf accuracy fix disconfirms "erf precision" as that issue's cause (see
   the updated #49 line below and the Issue #67 section).
+- 2026-07-19: created **#74 OPEN** (later fixed same session, see "x86
+  AVX2/AVX/SSE2 native validation audit" below) — `vector_log_sse2` was
+  missing the subnormal-input scaling that `vector_log_avx/avx2/avx512` all
+  have, silently returning `log(x)` up to ~35 natural-log-units off for
+  subnormal `x`. Found via native SSE2 testing enabled by the new
+  `LIBSTATS_MAX_SIMD_TIER` CMake cap; never caught before because SSE2 had
+  only previously run under Rosetta 2. https://github.com/OldCrow/libstats/issues/74
 - GitHub is the collaborator-facing source for issues and milestones; this
   PLAN.md is the agent-facing durable project state. Keep both in sync.
 - When creating, closing, reopening, retitling, or moving a GitHub issue or
@@ -104,6 +111,9 @@ Last reconciled against live GitHub state: 2026-07-19.
     LGPL-2.1+ `erf_advsimd.c`, not a permissively-licensed source. No MIT
     equivalent algorithm exists upstream; needs a dedicated remediation
     decision. See `THIRD_PARTY_NOTICES.md` "KNOWN ISSUE" section.
+  - #74 OPEN (created and fixed 2026-07-19, not yet closed pending PR/merge) —
+    `vector_log_sse2` subnormal-input bug. See "x86 AVX2/AVX/SSE2 native
+    validation audit" below.
 - Closed issues without milestone: 9 as of 2026-07-14.
 
 ## In Progress [OPEN]
@@ -436,13 +446,66 @@ Branch `fix/issue-67-erf-neon-cleanroom` (off `main`, pushed to origin, commit
 - Regression test added
   (`BatchMathRegressions.VectorExpDeepUnderflowMatchesStdExp`); on NEON it
   exercises the table kernel's fixup path, on x86 the new two-step scaling.
-- [OPEN] x86 kernels validated by cross-compile + SSE2 run under Rosetta 2
-  (clean); AVX/AVX2/AVX-512 need native-machine or CI validation (Kaby Lake,
-  Asus TUF A16).
+- [RESOLVED 2026-07-19] x86 kernels are now natively validated on Kaby Lake
+  for AVX2, AVX, *and* SSE2 (previously only AVX2 ran natively; AVX/SSE2 were
+  cross-compile/Rosetta-only) — see "x86 AVX2/AVX/SSE2 native validation
+  audit" below. AVX-512 still needs native-machine or CI validation on the
+  Asus TUF A16.
 - [OPEN] Pre-existing, unrelated: exp_max clamp constant is ~30 ULP (in x)
   below the true overflow threshold, so for x in that one-double window the
   kernels return exp(exp_max) (~214 ULP low) where std::exp is still finite.
   Deliberate safety margin against 1-ULP overshoot to inf; left as is.
+
+## x86 AVX2/AVX/SSE2 native validation audit (2026-07-19) [DERIVED]
+Follow-up audit requested after the exp underflow fix above shipped without
+native AVX/SSE2 coverage (Kaby Lake only runs AVX2 by default — runtime
+dispatch always selects the top supported tier, so AVX and SSE2 kernels never
+execute on this machine otherwise). Scope: everything changed since the
+`v2.0.4` tag, filtered to x86 production SIMD (`simd_sse2/avx/avx2/avx512.cpp`)
+— NEON changes and the opt-in `#66` gather dev-tooling were out of scope.
+- **Edge-case audit finding**: the exp underflow fix's clamp (`min(x, exp_max)`
+  / `max(x, exp_min)`) silently mapped `NaN` and any `x > exp_max` (including
+  `+inf` and true overflow) to a finite `~DBL_MAX`-ish value instead of
+  matching `std::exp`'s `NaN`/`+inf`. This also disagreed with the scalar
+  remainder loop in the same function (already `std::exp`) and with the NEON
+  kernel (routes `|x| >= 704` to scalar `std::exp`).
+- **Fix**: added a branchless post-clamp fixup to all four `vector_exp_*`
+  kernels — blend `+inf` where the *original* (pre-clamp) `x > exp_max`, blend
+  the original `x` (a NaN) where `x` is unordered vs itself. AVX2/AVX use
+  `_mm256_blendv_pd`; AVX-512 uses `_mm512_mask_blend_pd`; SSE2 has no
+  `blendv`, reuses the existing `SSE2_BLEND` and/andnot/or macro. Regression
+  test `BatchMathRegressions.VectorExpEdgeCasesMatchStdExp` added
+  (+inf/-inf/NaN/overflow points, 8x-repeated to hit every SIMD width).
+- **`LIBSTATS_MAX_SIMD_TIER` CMake option added** (`SIMDDetection.cmake`,
+  `apply_simd_tier_cap()`): caps the highest *compiled* x86 tier
+  (`SSE2|AVX|AVX2|AVX512`; empty = no cap, the default). Disabling a tier
+  removes its source file and compile definition, so the next tier down
+  becomes the dispatch ceiling — this is what let AVX and SSE2 run natively
+  on this AVX2-capable Kaby Lake box for the first time, rather than only via
+  cross-compile flag checks or Rosetta 2 emulation. Runs after
+  `apply_cross_compilation_overrides()` so an explicit cap wins over any
+  `LIBSTATS_FORCE_*`.
+- **Validation results** (Kaby Lake, Release): AVX2 (default) — 49/49 ctest,
+  `simd_verification` 70/70, edge probe confirms `+inf/NaN/overflow` now match
+  `std::exp`. AVX (`-DLIBSTATS_MAX_SIMD_TIER=AVX`) — same, natively, for the
+  first time. SSE2 (`-DLIBSTATS_MAX_SIMD_TIER=SSE2`) — same, natively, for the
+  first time, **after** the #74 fix below (see next bullet for the 3 failures
+  found before that fix).
+- **Side discovery — issue #74**: the first-ever native SSE2 run surfaced 3
+  pre-existing, unrelated `simd_verification` failures (`Gamma_EdgeCases`,
+  `Beta_EdgeCases`, `ChiSquared_EdgeCases`, `LogPDF`, max_diff ≈ 35.4) traced
+  to `vector_log_sse2` lacking the subnormal-input 2^54 scaling step that
+  `vector_log_avx/avx2/avx512` all have (subnormals have no implicit leading
+  mantissa bit, so the exponent/mantissa bit-extraction trick silently
+  produces a wrong result — e.g. `log(denorm_min())` returned -709.09 instead
+  of -744.44). Unrelated to the exp fix above (Gamma/Beta/ChiSquared `LogPDF`
+  never calls `vector_exp`). Filed and fixed same session: ported the AVX2
+  scaling block into `vector_log_sse2` via `SSE2_BLEND`; added
+  `BatchMathRegressions.VectorLogSubnormalMatchesStdLog`. Re-validated: SSE2
+  `simd_verification` 70/70 (was 67/70), ctest 49/49.
+  https://github.com/OldCrow/libstats/issues/74
+- **Not done this session**: no commit/PR yet for either fix (exp edge-cases
+  or #74) — working tree only, pending user review per SOP.
 
 ## Next Steps
 - Issue #33 x86 experiment (Q2) is fully closed null on both AVX2/Kaby Lake
@@ -464,6 +527,11 @@ Branch `fix/issue-67-erf-neon-cleanroom` (off `main`, pushed to origin, commit
   2026-07-19 rebase onto post-#70/#72 `main`.
 - Still assess `fix/remove-stale-vector-erfc-stub` (unrelated stale erfc-stub
   removal) for merge.
+- x86 AVX2/AVX/SSE2 native validation audit: both fixes (exp edge-cases,
+  `vector_log_sse2` subnormals / **#74**) are complete and validated in the
+  working tree but not yet committed — next concrete step is committing,
+  pushing, and opening a PR (or two), then closing **#74** once merged.
+  AVX-512 native validation on the Asus TUF A16 remains the one open tier.
 - Work through the v2.1.0 — Accuracy & Performance backlog (6 issues,
   mostly SIMD accuracy/perf gaps) before starting the new-distribution
   milestones (v2.2.0, v2.3.0) or the v3.0.0 architecture refactor.

--- a/cmake/SIMDDetection.cmake
+++ b/cmake/SIMDDetection.cmake
@@ -198,6 +198,79 @@ function(apply_cross_compilation_overrides)
         CACHE INTERNAL "List of SIMD compile definitions" FORCE)
 endfunction()
 
+# Cap the highest *compiled* x86 SIMD tier (LIBSTATS_MAX_SIMD_TIER). Runtime
+# dispatch always selects the highest tier the CPU supports, so lower-tier
+# kernels (e.g. AVX or SSE2 on an AVX2 box) otherwise never execute and cannot
+# be validated natively. This disables every x86 tier strictly above the cap and
+# removes its source + compile definition. Because it only ever removes from the
+# top, the downward dependency (AVX2 needs AVX needs SSE2) stays satisfied. Runs
+# after apply_cross_compilation_overrides(), so an explicit cap overrides any
+# LIBSTATS_FORCE_* that raised a tier. NEON is unaffected (ARM-only).
+function(apply_simd_tier_cap)
+    if(NOT DEFINED LIBSTATS_MAX_SIMD_TIER
+       OR LIBSTATS_MAX_SIMD_TIER STREQUAL ""
+       OR LIBSTATS_MAX_SIMD_TIER STREQUAL "NONE")
+        return()
+    endif()
+
+    string(TOUPPER "${LIBSTATS_MAX_SIMD_TIER}" _cap)
+    set(_tier_order SSE2 AVX AVX2 AVX512)
+    list(FIND _tier_order "${_cap}" _cap_rank)
+    if(_cap_rank EQUAL -1)
+        message(
+            FATAL_ERROR
+                "LIBSTATS_MAX_SIMD_TIER='${LIBSTATS_MAX_SIMD_TIER}' is invalid; "
+                "use one of: SSE2 AVX AVX2 AVX512 (or empty/NONE for no cap)")
+    endif()
+
+    get_property(
+        _sources
+        CACHE LIBSTATS_SIMD_SOURCES
+        PROPERTY VALUE)
+    get_property(
+        _definitions
+        CACHE LIBSTATS_SIMD_DEFINITIONS
+        PROPERTY VALUE)
+
+    set(_disabled "")
+    foreach(_tier IN LISTS _tier_order)
+        list(FIND _tier_order "${_tier}" _rank)
+        if(_rank GREATER _cap_rank)
+            get_property(
+                _was
+                CACHE LIBSTATS_HAS_${_tier}
+                PROPERTY VALUE)
+            set(LIBSTATS_HAS_${_tier}
+                FALSE
+                CACHE BOOL "${_tier} disabled by LIBSTATS_MAX_SIMD_TIER=${_cap}" FORCE)
+            # Source file name mirrors the tier: SSE2 -> src/simd_sse2.cpp, etc.
+            string(TOLOWER "${_tier}" _tier_lc)
+            list(REMOVE_ITEM _sources "src/simd_${_tier_lc}.cpp")
+            list(REMOVE_ITEM _definitions "LIBSTATS_HAS_${_tier}=1")
+            if(_was)
+                list(APPEND _disabled "${_tier}")
+            endif()
+        endif()
+    endforeach()
+
+    set(LIBSTATS_SIMD_SOURCES
+        "${_sources}"
+        CACHE INTERNAL "List of SIMD source files to compile" FORCE)
+    set(LIBSTATS_SIMD_DEFINITIONS
+        "${_definitions}"
+        CACHE INTERNAL "List of SIMD compile definitions" FORCE)
+
+    if(_disabled)
+        string(JOIN ", " _disabled_str ${_disabled})
+        message(STATUS "SIMD: capped at ${_cap} via LIBSTATS_MAX_SIMD_TIER; disabled: ${_disabled_str}")
+    else()
+        message(
+            STATUS
+                "SIMD: LIBSTATS_MAX_SIMD_TIER=${_cap} is at or above the detected top tier; no tiers removed"
+        )
+    endif()
+endfunction()
+
 # Main function to detect all SIMD features
 function(detect_simd_features)
     message(STATUS "Detecting SIMD features...")
@@ -243,9 +316,10 @@ function(detect_simd_features)
             set(LIBSTATS_SIMD_DEFINITIONS
                 "LIBSTATS_HAS_SSE2=1"
                 CACHE INTERNAL "List of SIMD compile definitions" FORCE)
-            message(STATUS "SIMD: SSE2 enabled (compiler only - cross-compiling)")
+        message(STATUS "SIMD: SSE2 enabled (compiler only - cross-compiling)")
         endif()
         apply_cross_compilation_overrides()
+        apply_simd_tier_cap()
         # Always include fallback implementation
         get_property(
             _sources
@@ -676,6 +750,9 @@ bool test_neon() {
     # Apply any environment variable overrides
     apply_cross_compilation_overrides()
 
+    # Cap the compiled tier if requested (must run after overrides so an explicit
+    # cap wins over any LIBSTATS_FORCE_* that raised a tier).
+    apply_simd_tier_cap()
 
     # Always include fallback implementation
     get_property(

--- a/src/simd_avx.cpp
+++ b/src/simd_avx.cpp
@@ -179,6 +179,7 @@ void VectorOps::vector_exp_avx(const double* input, double* output, std::size_t 
     //   exp(-708) ~ 3.3e-308 instead of flushing through the subnormal range.
     const __m256d exp_max = _mm256_set1_pd(709.782712893383996732223);
     const __m256d exp_min = _mm256_set1_pd(-746.0);
+    const __m256d pos_inf = _mm256_set1_pd(std::numeric_limits<double>::infinity());
 
     // SLEEF polynomial coefficients for exp(s) where |s| < ln(2)/2
     // These provide < 1 ULP error for double precision
@@ -197,10 +198,10 @@ void VectorOps::vector_exp_avx(const double* input, double* output, std::size_t 
     const std::size_t simd_end = (size / AVX_DOUBLE_WIDTH) * AVX_DOUBLE_WIDTH;
 
     for (std::size_t i = 0; i < simd_end; i += AVX_DOUBLE_WIDTH) {
-        __m256d x = _mm256_loadu_pd(&input[i]);
+        __m256d x_orig = _mm256_loadu_pd(&input[i]);
 
         // Clamp to avoid overflow/underflow
-        x = _mm256_min_pd(x, exp_max);
+        __m256d x = _mm256_min_pd(x_orig, exp_max);
         x = _mm256_max_pd(x, exp_min);
 
         // Range reduction: x = n*ln(2) + r
@@ -266,6 +267,13 @@ void VectorOps::vector_exp_avx(const double* input, double* output, std::size_t 
 
         // Final result: exp(x) = exp(r) * 2^n1 * 2^n2
         __m256d result = _mm256_mul_pd(_mm256_mul_pd(poly, scale1), scale2);
+
+        // Match std::exp at the non-finite/overflow edges: x > exp_max (incl.
+        // +inf) -> +inf, NaN -> NaN. Underflow/-inf already flush to +0, so no
+        // low-side fixup is needed. Keeps the SIMD body consistent with the
+        // scalar remainder loop below (std::exp) and the NEON kernel.
+        result = _mm256_blendv_pd(result, pos_inf, _mm256_cmp_pd(x_orig, exp_max, _CMP_GT_OQ));
+        result = _mm256_blendv_pd(result, x_orig, _mm256_cmp_pd(x_orig, x_orig, _CMP_UNORD_Q));
 
         _mm256_storeu_pd(&output[i], result);
     }

--- a/src/simd_avx2.cpp
+++ b/src/simd_avx2.cpp
@@ -208,6 +208,7 @@ void VectorOps::vector_exp_avx2(const double* input, double* output, std::size_t
     const __m256d exp_min = _mm256_set1_pd(-746.0);
     const __m256d half = _mm256_set1_pd(0.5);
     const __m256d one = _mm256_set1_pd(1.0);
+    const __m256d pos_inf = _mm256_set1_pd(std::numeric_limits<double>::infinity());
 
     const __m256d c1 = _mm256_set1_pd(0.1666666666666669072e+0);
     const __m256d c2 = _mm256_set1_pd(0.4166666666666602598e-1);
@@ -224,8 +225,8 @@ void VectorOps::vector_exp_avx2(const double* input, double* output, std::size_t
     const std::size_t simd_end = (size / W) * W;
 
     for (std::size_t i = 0; i < simd_end; i += W) {
-        __m256d x = _mm256_loadu_pd(&input[i]);
-        x = _mm256_min_pd(x, exp_max);
+        __m256d x_orig = _mm256_loadu_pd(&input[i]);
+        __m256d x = _mm256_min_pd(x_orig, exp_max);
         x = _mm256_max_pd(x, exp_min);
 
         // Range reduction: x = n*ln2 + r
@@ -268,7 +269,16 @@ void VectorOps::vector_exp_avx2(const double* input, double* output, std::size_t
         __m128i e2_hi = _mm_slli_epi64(_mm_cvtepi32_epi64(_mm_shuffle_epi32(eb2, 0x0E)), 52);
         __m256d scale1 = _mm256_set_m128d(_mm_castsi128_pd(e1_hi), _mm_castsi128_pd(e1_lo));
         __m256d scale2 = _mm256_set_m128d(_mm_castsi128_pd(e2_hi), _mm_castsi128_pd(e2_lo));
-        _mm256_storeu_pd(&output[i], _mm256_mul_pd(_mm256_mul_pd(poly, scale1), scale2));
+        __m256d result = _mm256_mul_pd(_mm256_mul_pd(poly, scale1), scale2);
+
+        // Match std::exp at the non-finite/overflow edges (the clamp above only
+        // guarantees the finite in-range path): x > exp_max (incl. +inf) -> +inf,
+        // NaN -> NaN. Underflow/-inf already flush to +0 via exp_min + two-step
+        // scaling, so no low-side fixup is needed. Keeps the SIMD body consistent
+        // with the scalar remainder loop below (std::exp) and the NEON kernel.
+        result = _mm256_blendv_pd(result, pos_inf, _mm256_cmp_pd(x_orig, exp_max, _CMP_GT_OQ));
+        result = _mm256_blendv_pd(result, x_orig, _mm256_cmp_pd(x_orig, x_orig, _CMP_UNORD_Q));
+        _mm256_storeu_pd(&output[i], result);
     }
 
     for (std::size_t i = simd_end; i < size; ++i)

--- a/src/simd_avx512.cpp
+++ b/src/simd_avx512.cpp
@@ -182,6 +182,7 @@ void VectorOps::vector_exp_avx512(const double* values, double* results,
     const __m512d exp_min = _mm512_set1_pd(-746.0);
     const __m512d half = _mm512_set1_pd(0.5);
     const __m512d one = _mm512_set1_pd(1.0);
+    const __m512d pos_inf = _mm512_set1_pd(std::numeric_limits<double>::infinity());
 
     const __m512d c1 = _mm512_set1_pd(0.1666666666666669072e+0);
     const __m512d c2 = _mm512_set1_pd(0.4166666666666602598e-1);
@@ -198,8 +199,8 @@ void VectorOps::vector_exp_avx512(const double* values, double* results,
     const std::size_t simd_end = (size / W) * W;
 
     for (std::size_t i = 0; i < simd_end; i += W) {
-        __m512d x = _mm512_loadu_pd(&values[i]);
-        x = _mm512_min_pd(x, exp_max);
+        __m512d x_orig = _mm512_loadu_pd(&values[i]);
+        __m512d x = _mm512_min_pd(x_orig, exp_max);
         x = _mm512_max_pd(x, exp_min);
 
         // Range reduction: x = n*ln2 + r
@@ -240,7 +241,16 @@ void VectorOps::vector_exp_avx512(const double* values, double* results,
         __m512d scale1 = _mm512_castsi512_pd(e1);
         __m512d scale2 = _mm512_castsi512_pd(e2);
 
-        _mm512_storeu_pd(&results[i], _mm512_mul_pd(_mm512_mul_pd(poly, scale1), scale2));
+        __m512d result = _mm512_mul_pd(_mm512_mul_pd(poly, scale1), scale2);
+        // Match std::exp at the non-finite/overflow edges: x > exp_max (incl.
+        // +inf) -> +inf, NaN -> NaN. Underflow/-inf already flush to +0 via
+        // exp_min + two-step scaling. Keeps the SIMD body consistent with the
+        // scalar remainder loop below (std::exp) and the NEON kernel.
+        result = _mm512_mask_blend_pd(_mm512_cmp_pd_mask(x_orig, exp_max, _CMP_GT_OQ), result,
+                                      pos_inf);
+        result = _mm512_mask_blend_pd(_mm512_cmp_pd_mask(x_orig, x_orig, _CMP_UNORD_Q), result,
+                                      x_orig);
+        _mm512_storeu_pd(&results[i], result);
     }
 
     for (std::size_t i = simd_end; i < size; ++i)

--- a/src/simd_sse2.cpp
+++ b/src/simd_sse2.cpp
@@ -182,6 +182,7 @@ void VectorOps::vector_exp_sse2(const double* values, double* results, std::size
     const __m128d exp_min = _mm_set1_pd(-746.0);
     const __m128d half = _mm_set1_pd(0.5);
     const __m128d one = _mm_set1_pd(1.0);
+    const __m128d pos_inf = _mm_set1_pd(std::numeric_limits<double>::infinity());
     // Magic-number rounding constant: 2^52 + 2^51 = 6755399441055744; adding it to x
     // rounds x (as double) to integer in the binade [2^51, 2^52], then subtracting it back
     // yields round(x) without SSE4.1 _mm_round_pd.
@@ -202,8 +203,8 @@ void VectorOps::vector_exp_sse2(const double* values, double* results, std::size
     const std::size_t simd_end = (size / W) * W;
 
     for (std::size_t i = 0; i < simd_end; i += W) {
-        __m128d x = _mm_loadu_pd(&values[i]);
-        x = _mm_min_pd(x, exp_max);
+        __m128d x_orig = _mm_loadu_pd(&values[i]);
+        __m128d x = _mm_min_pd(x_orig, exp_max);
         x = _mm_max_pd(x, exp_min);
 
         // Range reduction: n = round(x / ln2) via magic-number trick
@@ -250,7 +251,14 @@ void VectorOps::vector_exp_sse2(const double* values, double* results, std::size
         __m128d scale1 = _mm_castsi128_pd(e1);
         __m128d scale2 = _mm_castsi128_pd(e2);
 
-        _mm_storeu_pd(&results[i], _mm_mul_pd(_mm_mul_pd(poly, scale1), scale2));
+        __m128d result = _mm_mul_pd(_mm_mul_pd(poly, scale1), scale2);
+        // Match std::exp at the non-finite/overflow edges (SSE2 has no blendv):
+        // x > exp_max (incl. +inf) -> +inf, NaN -> NaN. Underflow/-inf already
+        // flush to +0 via exp_min + two-step scaling. Keeps the SIMD body
+        // consistent with the scalar remainder loop below (std::exp).
+        result = SSE2_BLEND(_mm_cmpgt_pd(x_orig, exp_max), pos_inf, result);
+        result = SSE2_BLEND(_mm_cmpunord_pd(x_orig, x_orig), x_orig, result);
+        _mm_storeu_pd(&results[i], result);
     }
 
     for (std::size_t i = simd_end; i < size; ++i)
@@ -288,16 +296,29 @@ void VectorOps::vector_log_sse2(const double* values, double* results, std::size
     for (std::size_t i = 0; i < simd_end; i += W) {
         __m128d x = _mm_loadu_pd(&values[i]);
 
-        // Special-case detection
+        // Special-case detection (on the original, unscaled x)
         __m128d is_zero = _mm_cmpeq_pd(x, zero);
         __m128d is_negative = _mm_cmplt_pd(x, zero);
         __m128d is_inf = _mm_cmpeq_pd(x, pos_inf);
+
+        // Scale subnormal inputs by 2^54 before bit-level exponent/mantissa
+        // extraction below: subnormals have no implicit leading mantissa bit, so
+        // the "exponent field + forced mantissa bias" trick is only valid for
+        // normalized doubles. Without this, log(denormal) silently returns a
+        // value up to ~35 natural-log-units off (e.g. log(denorm_min()) came out
+        // as -709.09 instead of -744.44). Same fix as vector_log_avx/avx2/avx512;
+        // ported here 2026-07-19 after native SSE2 testing (via
+        // LIBSTATS_MAX_SIMD_TIER) surfaced the gap for the first time.
+        const __m128d min_normal = _mm_set1_pd(2.2250738585072014e-308);
+        const __m128d scale_up = _mm_set1_pd(18014398509481984.0);  // 2^54
+        __m128d is_denormal = _mm_cmplt_pd(x, min_normal);
+        __m128d scaled_x = SSE2_BLEND(is_denormal, _mm_mul_pd(x, scale_up), x);
 
         // Exponent extraction: cast to int, srli_epi64 by 52, mask 11-bit field, subtract 1023.
         // _mm_srli_epi64 shifts each 64-bit element right: exponent lands in bits [0..10].
         // _mm_shuffle_epi32 + _mm_cvtepi32_pd converts the two 32-bit exponent values to double
         // without SSE4.1 _mm_cvtepi64_pd: the exponent fits in 32 bits (0..2046).
-        __m128i xi = _mm_castpd_si128(x);
+        __m128i xi = _mm_castpd_si128(scaled_x);
         __m128i exp_i = _mm_srli_epi64(xi, 52);
         exp_i = _mm_and_si128(exp_i, _mm_set1_epi64x(0x7FFLL));
         // exp_i = [exp0:64, exp1:64]; lower 32 bits of each 64-bit lane hold the value.
@@ -305,6 +326,8 @@ void VectorOps::vector_log_sse2(const double* values, double* results, std::size
         __m128i exp_i32 = _mm_shuffle_epi32(exp_i, _MM_SHUFFLE(0, 0, 2, 0));
         __m128d e = _mm_cvtepi32_pd(exp_i32);
         e = _mm_sub_pd(e, _mm_set1_pd(1023.0));
+        // Undo the 2^54 scaling's contribution to the exponent for denormal lanes.
+        e = SSE2_BLEND(is_denormal, _mm_sub_pd(e, _mm_set1_pd(54.0)), e);
 
         // Mantissa: clear exponent field, set exponent to 1023 (=> m in [1,2))
         __m128i mant_mask = _mm_set1_epi64x(0x000FFFFFFFFFFFFFLL);

--- a/tests/test_batch_math_regressions.cpp
+++ b/tests/test_batch_math_regressions.cpp
@@ -154,6 +154,80 @@ TEST(BatchMathRegressions, VectorExpDeepUnderflowMatchesStdExp) {
     }
 }
 
+TEST(BatchMathRegressions, VectorExpEdgeCasesMatchStdExp) {
+    // Companion to VectorExpDeepUnderflowMatchesStdExp. The SIMD exp kernels
+    // clamp inputs into [exp_min, exp_max] for the finite path, so non-finite
+    // and overflow inputs need an explicit fixup to track std::exp. Guards the
+    // 2026-07-19 AVX2/AVX audit findings: +inf/overflow -> +inf, NaN -> NaN,
+    // -inf -> +0, and the SIMD body must agree with the scalar remainder loop
+    // (also std::exp). Before the fix these lanes returned ~DBL_MAX (a finite
+    // value), silently swallowing NaN and +inf.
+    const double inf = std::numeric_limits<double>::infinity();
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double points[] = {inf, -inf, nan, 710.0, 720.0, 1.0e6, -1.0, 2.5, -37.0, 0.0};
+    // Repeat each value 8x so every SIMD width (2/4/8 doubles) hits the vector
+    // kernel rather than the scalar remainder loop.
+    std::vector<double> values;
+    for (double p : points)
+        values.insert(values.end(), 8, p);
+    std::vector<double> out(values.size());
+
+    arch::simd::VectorOps::vector_exp(values.data(), out.data(), values.size());
+
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        const double x = values[i];
+        const double ref = std::exp(x);
+        if (std::isnan(ref)) {
+            EXPECT_TRUE(std::isnan(out[i])) << "x=" << x << " simd=" << out[i];
+        } else if (std::isinf(ref)) {
+            EXPECT_TRUE(std::isinf(out[i]) && out[i] > 0.0) << "x=" << x << " simd=" << out[i];
+        } else {
+            // Finite: exp(x) >= +0, so bit patterns are ordered and their
+            // difference is the ULP distance.
+            const auto ulp =
+                std::abs(std::bit_cast<std::int64_t>(out[i]) - std::bit_cast<std::int64_t>(ref));
+            EXPECT_LE(ulp, 4) << "x=" << x << " simd=" << out[i] << " ref=" << ref;
+            if (ref == 0.0)
+                EXPECT_FALSE(std::signbit(out[i])) << "x=" << x << " returned -0";
+        }
+    }
+}
+
+TEST(BatchMathRegressions, VectorLogSubnormalMatchesStdLog) {
+    // vector_log_avx/avx2/avx512 scale subnormal inputs by 2^54 before the
+    // bit-level exponent/mantissa extraction (subnormals have no implicit
+    // leading mantissa bit, so the trick is only valid for normalized
+    // doubles). vector_log_sse2 was missing this scaling entirely, so
+    // log(subnormal) was silently wrong by up to ~35 natural-log-units (e.g.
+    // log(denorm_min()) returned -709.09 instead of -744.44). Found
+    // 2026-07-19 via native SSE2 testing (LIBSTATS_MAX_SIMD_TIER=SSE2), which
+    // surfaced this for the first time -- SSE2 had previously only run under
+    // Rosetta 2. Guards the fix across whichever tier is dispatched.
+    const double points[] = {
+        std::numeric_limits<double>::denorm_min(),  // smallest subnormal, ~4.94e-324
+        1.0e-310,                                   // subnormal
+        1.0e-320,                                   // subnormal
+        std::numeric_limits<double>::min(),         // smallest normal, ~2.22e-308 (boundary)
+        1.0,
+        1.0e100,
+        std::numeric_limits<double>::max(),
+    };
+    // Repeat each value 8x so every SIMD width (2/4/8 doubles) hits the vector
+    // kernel rather than the scalar remainder loop.
+    std::vector<double> values;
+    for (double p : points)
+        values.insert(values.end(), 8, p);
+    std::vector<double> out(values.size());
+
+    arch::simd::VectorOps::vector_log(values.data(), out.data(), values.size());
+
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        const double ref = std::log(values[i]);
+        EXPECT_NEAR(out[i], ref, std::abs(ref) * 1e-9 + 1e-12)
+            << "x=" << values[i] << " simd=" << out[i] << " ref=" << ref;
+    }
+}
+
 TEST(BatchMathRegressions, GaussianStandardizedValueRebuildsCacheAfterReset) {
     auto gaussian = GaussianDistribution::create(10.0, 2.0).unwrap();
     EXPECT_NEAR(gaussian.getStandardizedValue(14.0), 2.0, 1e-15);


### PR DESCRIPTION
## Summary
Audit of x86 SIMD code changed since v2.0.4 (the #68 exp underflow fix), covering AVX2/AVX/SSE2/AVX-512, with native validation of every tier on Kaby Lake via a new `LIBSTATS_MAX_SIMD_TIER` CMake cap.

**Draft PR — opened to trigger CI. Not yet ready for review/merge.**

### 1. `vector_exp_*` non-finite/overflow fix (AVX2, AVX, SSE2, AVX-512)
The #68 underflow fix's clamp (`min(x, exp_max)` / `max(x, exp_min)`) silently mapped `NaN` and any `x > exp_max` (including `+inf` and true overflow) to a finite `~DBL_MAX`-ish value instead of matching `std::exp`'s `NaN`/`+inf`. This disagreed with the scalar remainder loop in the same function (already `std::exp`) and with the NEON kernel (routes `|x| >= 704` to scalar `std::exp`).

Fix: branchless post-clamp blend using the *original* (pre-clamp) `x` — `+inf` where `x > exp_max`, propagate `x` itself where `x` is unordered (NaN). New test: `BatchMathRegressions.VectorExpEdgeCasesMatchStdExp`.

### 2. `LIBSTATS_MAX_SIMD_TIER` CMake option
Runtime dispatch always selects the highest tier the CPU supports, so on an AVX2-capable box the AVX and SSE2 kernels never executed — they had only ever been validated via cross-compile flag checks or under Rosetta 2. Added `LIBSTATS_MAX_SIMD_TIER` (`SSE2|AVX|AVX2|AVX512`; empty = no cap) via a new `apply_simd_tier_cap()` in `SIMDDetection.cmake`, letting lower tiers run natively for the first time.

### 3. `vector_log_sse2` subnormal-input bug (issue #74)
Native SSE2 validation (enabled by the option above) surfaced 3 pre-existing `simd_verification` failures (`Gamma_EdgeCases`/`Beta_EdgeCases`/`ChiSquared_EdgeCases` `LogPDF`, max_diff ≈ 35.4). Root cause: `vector_log_avx/avx2/avx512` all scale subnormal inputs by 2^54 before bit-level exponent/mantissa extraction (subnormals have no implicit leading mantissa bit) — `vector_log_sse2` never had this. Fixed by porting the AVX2 scaling block via the existing `SSE2_BLEND` macro. New test: `BatchMathRegressions.VectorLogSubnormalMatchesStdLog`.

Fixes #74.

## Validation (Kaby Lake, Release, each tier native via the new cap)
- AVX2 (default): 49/49 ctest, `simd_verification` 70/70.
- AVX (`-DLIBSTATS_MAX_SIMD_TIER=AVX`): 49/49 ctest, `simd_verification` 70/70 — first native run ever.
- SSE2 (`-DLIBSTATS_MAX_SIMD_TIER=SSE2`): 49/49 ctest, `simd_verification` 70/70 (was 67/70 before the log fix) — first native run ever.
- AVX-512: unchanged, still needs native Zen4/CI validation (out of scope).

[Conversation](https://app.warp.dev/conversation/2d83ed47-2c2a-46bc-bdc9-389f57b77f69)

Co-Authored-By: Oz <oz-agent@warp.dev>