### PR TITLE
fix: remove stale vector_erfc stub; document why it is not needed

### DIFF
--- a/include/core/math_utils.h
+++ b/include/core/math_utils.h
@@ -157,12 +157,10 @@ namespace detail {
  */
 void vector_erf(std::span<const double> input, std::span<double> output) noexcept;
 
-// DEFERRED: vector_erfc
-// Target: Gaussian CDF error-function-complement SIMD path; would eliminate
-//   the scalar fallback for erfc() in the Gaussian CDF batch kernel.
-// Prerequisite: an erfc SIMD primitive (currently only vector_erf exists).
-//   Low priority: erf is the dominant operation; erfc is a derived quantity.
-void vector_erfc(std::span<const double> input, std::span<double> output) noexcept;
+// NOTE: vector_erfc is intentionally absent.
+// The Gaussian CDF batch path uses 0.5*(1 + erf(x/√2)) via vector_erf directly
+// (see gaussian.cpp getCumulativeProbabilityBatchUnsafeImpl). No distribution
+// batch path calls erfc, so a SIMD erfc primitive has no hot-path target.
 
 // DEFERRED: vector_gamma_p / vector_gamma_q
 // Target: Gamma/ChiSquared/Poisson CDF batch SIMD acceleration.

--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -711,19 +711,6 @@ void vector_erf(std::span<const double> input, std::span<double> output) noexcep
     }
 }
 
-void vector_erfc(std::span<const double> input, std::span<double> output) noexcept {
-    if (input.size() != output.size() || input.empty()) {
-        return;
-    }
-
-    const std::size_t size = input.size();
-
-    // Use scalar loop for now - SIMD erfc would require implementation
-    for (std::size_t i = 0; i < size; ++i) {
-        output[i] = erfc(input[i]);
-    }
-}
-
 void vector_gamma_p(double a, std::span<const double> x_values, std::span<double> output) noexcept {
     if (x_values.size() != output.size() || x_values.empty()) {
         return;

--- a/tests/test_math_comprehensive.cpp
+++ b/tests/test_math_comprehensive.cpp
@@ -145,23 +145,8 @@ TEST_F(MathUtilsTest, VectorizedErf) {
 
     EXPECT_TRUE(accurate) << "Max error: " << max_error << " (limit: " << ERF_VECTORIZED_TOLERANCE
                           << ")";
-
-    // Test vector_erfc — same accuracy as vector_erf since erfc(x) = 1 - erf(x)
-    stats::detail::vector_erfc(input, output);
-
-    accurate = true;
-    max_error = 0.0;
-    for (size_t i = 0; i < size; ++i) {
-        expected[i] = stats::detail::erfc(input[i]);
-        double error = std::abs(output[i] - expected[i]);
-        max_error = std::max(max_error, error);
-        if (error > ERF_VECTORIZED_TOLERANCE) {
-            accurate = false;
-        }
-    }
-
-    EXPECT_TRUE(accurate) << "Max error: " << max_error << " (limit: " << ERF_VECTORIZED_TOLERANCE
-                          << ")";
+    // Note: vector_erfc is intentionally removed. The Gaussian CDF uses
+    // 0.5*(1 + vector_erf(x)) directly; no batch path calls erfc.
 }
 
 TEST_F(MathUtilsTest, VectorizedGamma) {
@@ -255,7 +240,6 @@ TEST_F(MathUtilsTest, VectorizedEdgeCases) {
 
     // Should handle without crashing
     stats::detail::vector_erf(special_in, special_out);
-    stats::detail::vector_erfc(special_in, special_out);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary
Removes the unused `vector_erfc` SIMD stub. No distribution batch path calls `erfc()` — the Gaussian CDF batch path uses `0.5*(1 + vector_erf(x/√2))` directly (`getCumulativeProbabilityBatchUnsafeImpl`), so a SIMD `erfc` primitive has no hot-path target. Scalar `erfc()` is retained (used by `distribution_base.cpp`).

Removed from:
- `include/core/math_utils.h` (declaration, replaced with an explanatory `NOTE:` comment)
- `src/math_utils.cpp` (implementation)
- `tests/test_math_comprehensive.cpp` (the two test call sites)

## Validation
Rebased onto current `main` 2026-07-19 (its base had zero drift on the three touched files, so the rebase was conflict-free) and re-validated:
- 49/49 `ctest` correctness suite pass
- `simd_verification` 70/70 pass, `VectorErf` unaffected (2.0x)
- No remaining references to `vector_erfc` anywhere in the tree

Note: one unrelated timing test (`GaussianEnhancedTest.CachingSpeedupVerification`) is flaky on the local dev machine at the moment — confirmed via a fresh build of unmodified `main` in an isolated worktree, which reproduces the same failure. Not caused by this change; it's a nanosecond-scale cache-hit/miss measurement, exactly the class of test the project's own docs flag as requiring a quiet dedicated machine.

Co-Authored-By: Oz <oz-agent@warp.dev>